### PR TITLE
24 Part 6: Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ path = (
 img = BioImage(path)
 print(img.shape)  # (1, 1, 1, 5684, 5925)
 ```
+Note: accessing files from the internet is not available in `aicspylibczi` mode.
 
 ### Individual tiles with aicspylibczi
 ```python

--- a/README.md
+++ b/README.md
@@ -54,8 +54,15 @@ print(img.shape)  # (1, 1, 1, 5684, 5925)
 
 ### Individual tiles with aicspylibczi
 ```python
-img = BioImage("S=2_4x2_T=2=Z=3_CH=2.czi", reconstruct_mosaic=False, use_aicspylibczi=True)
+img = BioImage(
+    "S=2_4x2_T=2=Z=3_CH=2.czi",
+    reconstruct_mosaic=False,
+    include_subblock_metadata=True,
+    use_aicspylibczi=True
+)
 print(img.dims)  # <Dimensions [M: 8, T: 2, C: 2, Z: 3, Y: 256, X: 256]>
+subblocks = img.metadata.findall("./Subblocks/Subblock")
+print(len(subblocks))  # 192
 ```
 The `M` dimension is used to select a specific tile.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A BioIO reader plugin for reading CZIs using `pylibczirw` or `aicspylibczi`
 
 ## Documentation
 
-[See the generic bioio documentation on our GitHub pages site](https://bioio-devs.github.io/bioio/OVERVIEW.html) - the generic use and installation instructions there will work for this package.
+[See the bioio documentation on our GitHub pages site](https://bioio-devs.github.io/bioio/OVERVIEW.html) - the general use and installation instructions there will work for this package.
 
 Information about the base reader this package relies on can be found in the `bioio-base` repository [here](https://github.com/bioio-devs/bioio-base).
 

--- a/README.md
+++ b/README.md
@@ -5,29 +5,68 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9,3.10,3.11-blue.svg)](https://www.python.org/downloads/release/python-390/)
 
-A BioIO reader plugin for reading CZIs using `aicspylibczi`
+A BioIO reader plugin for reading CZIs using `pylibczirw` or `aicspylibczi`
 
 ---
 
 
 ## Documentation
 
-[See the full documentation on our GitHub pages site](https://bioio-devs.github.io/bioio/OVERVIEW.html) - the generic use and installation instructions there will work for this package.
+[See the generic bioio documentation on our GitHub pages site](https://bioio-devs.github.io/bioio/OVERVIEW.html) - the generic use and installation instructions there will work for this package.
 
-Information about the base reader this package relies on can be found in the `bioio-base` repository [here](https://github.com/bioio-devs/bioio-base)
+Information about the base reader this package relies on can be found in the `bioio-base` repository [here](https://github.com/bioio-devs/bioio-base).
 
 ## Installation
-
-**Stable Release:** `pip install bioio-czi`<br>
-**Development Head:** `pip install git+https://github.com/bioio-devs/bioio-czi.git`
-
-## Example Usage (see full documentation for more examples)
 
 Install bioio-czi alongside bioio:
 
 `pip install bioio bioio-czi`
 
+**Stable Release:** `pip install bioio-czi`<br>
+**Development Head:** `pip install git+https://github.com/bioio-devs/bioio-czi.git`
 
+## pylibczirw vs. aicspylibczi
+`bioio-czi` can operate in [pylibczirw](https://github.com/ZEISS/pylibczirw) mode (the default) or [aicspylibczi](https://github.com/AllenCellModeling/aicspylibczi) mode.
+
+| Feature | pylibczirw mode | aicspylibczi mode |
+|--|--|--|
+| Read CZIs from the internet | ✅ | ❌ |
+| Read single tile from tiled CZI | ❌ | ✅ |
+| Read single tile's metadata from tiled CZI | ❌ | ✅ |
+| Read stitched mosaic of a tiled CZI | ✅ | ✅ |
+
+The primary difference is that `pylibczirw` supports reading CZIs over the internet but cannot access individual tiles from a tiled CZI. To use `aicspylibczi`, add the `use_aicspylibczi=True` parameter when creating a reader. For example: `from bioio import BioImage; img = BioImage(..., use_aicspylibczi=True)`.
+
+## Example Usage (see full documentation for more examples)
+
+### Basic usage
+```python
+from bioio import BioImage
+
+path = (
+    "https://allencell.s3.amazonaws.com/aics/hipsc_12x_overview_image_dataset/"
+    "stitchedwelloverviewimagepath/05080558_3500003720_10X_20191220_D3.czi"
+)
+
+img = BioImage(path)
+print(img.shape)  # (1, 1, 1, 5684, 5925)
+```
+
+### Individual tiles with aicspylibczi
+```python
+img = BioImage("S=2_4x2_T=2=Z=3_CH=2.czi", reconstruct_mosaic=False, use_aicspylibczi=True)
+print(img.dims)  # <Dimensions [M: 8, T: 2, C: 2, Z: 3, Y: 256, X: 256]>
+```
+The `M` dimension is used to select a specific tile.
+
+### Stitched mosaic with pylibczirw
+```python
+img = BioImage("S=2_4x2_T=2=Z=3_CH=2.czi")
+print(img.dims)  # <Dimensions [T: 2, C: 2, Z: 3, Y: 487, X: 947]>
+```
+All 8 tiles are stitched together. Where tiles overlap, the pixel value is the pixel value from the tile with the highest M-index.
+
+### Explicit Reader
 This example shows a simple use case for just accessing the pixel data of the image
 by explicitly passing this `Reader` into the `BioImage`. Passing the `Reader` into
 the `BioImage` instance is optional as `bioio` will automatically detect installed

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ img = BioImage(
 print(img.dims)  # <Dimensions [M: 8, T: 2, C: 2, Z: 3, Y: 256, X: 256]>
 subblocks = img.metadata.findall("./Subblocks/Subblock")
 print(len(subblocks))  # 192
+print(img.get_image_data("TCZYX", M=3).shape)  # (2, 2, 3, 256, 256)
 ```
 The `M` dimension is used to select a specific tile.
 


### PR DESCRIPTION
# Context
Part of #24, now almost complete with the other PRs open here.

# Changes
Document the main nuances of `aicspylibczi` vs. `pylibczirw` for our users in the README.

User-facing bioio-czi documentation could go in a new bioio-czi Read the Docs page, but (1) we'd probably want to put full API docs there if we did, which would overlap substantially with the bioio Read the Docs, and (2) bioio's Read the Docs links to https://github.com/bioio-devs/bioio-czi/.