### PR TITLE
24: Improve error message for incorrect mode

### DIFF
--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -83,17 +83,12 @@ class Reader(BaseReader):
 
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
+        if not isinstance(fs, LocalFileSystem):
+            return False
         try:
-            if not isinstance(fs, LocalFileSystem):
-                raise ValueError(
-                    f"Cannot read CZIs from non-local file system. "
-                    f"Received URI: {path}, which points to {type(fs)}."
-                )
-
             with fs.open(path) as open_resource:
                 CziFile(open_resource.f)
                 return True
-
         except RuntimeError:
             return False
 
@@ -131,9 +126,10 @@ class Reader(BaseReader):
 
         # Catch non-local file system
         if not isinstance(self._fs, LocalFileSystem):
-            raise ValueError(
-                f"Cannot read CZIs from non-local file system. "
-                f"Received URI: {self._path}, which points to {type(self._fs)}."
+            raise exceptions.UnsupportedFileFormatError(
+                "bioio-czi[aicspylibczi mode]",
+                self._path,
+                "Try not setting use_aicspylibczi?",
             )
 
         # Store params

--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -99,7 +99,6 @@ class Reader(BaseReader):
             Any specific keyword arguments to pass to the fsspec-created filesystem.
             Default: {}
         """
-        # TODO handle case where "wrong" reader is called
         if use_aicspylibczi:
             self._implementation = AicsPyLibCziReader(image, **kwargs)
         else:

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -198,10 +198,16 @@ def test_czi_reader(
     )
 
 
-@pytest.mark.xfail(reason="Do no support remote CZI reading yet")
+@pytest.mark.xfail(
+    raises=exceptions.UnsupportedFileFormatError,
+    reason="Do no support remote CZI reading in aicspylibczi mode",
+)
 def test_czi_reader_remote_xfail() -> None:
     # Construct full filepath
-    uri = LOCAL_RESOURCES_DIR / "s_1_t_1_c_1_z_1.czi"
+    uri = (
+        "https://allencell.s3.amazonaws.com/aics/hipsc_12x_overview_image_dataset/"
+        "stitchedwelloverviewimagepath/05080558_3500003720_10X_20191220_D3.czi"
+    )
     Reader(uri, use_aicspylibczi=True)
 
 


### PR DESCRIPTION
# Context
It's possible for the bioio-czi plugin to return `True` from `_is_supported_image` but then the user gets an error when trying to load the image in aicspylibczi mode. This could be confusing for users, so we can try to assist with a good error message.

I anticipate this is the final PR for #24.

# Changes
* Improve error message when reading remote paths with aicspylibczi mode
* Fix an old test for when aicspylibczi reads a remote file (it claimed to be about reading remote files but was actually trying to read a local file? Unless I misunderstand what "remote CZI" meant to the original author.)

# Testing
Unit tests pass.

```python
from bioio import BioImage

path = (
    "https://allencell.s3.amazonaws.com/aics/hipsc_12x_overview_image_dataset/"
    "stitchedwelloverviewimagepath/05080558_3500003720_10X_20191220_D3.czi"
)

img = BioImage(path, use_aicspylibczi=True)from bioio import BioImage
```
The above results in the following error.
`UnsupportedFileFormatError: bioio-czi[aicspylibczi mode] does not support the image: 'https://allencell.s3.amazonaws.com/aics/hipsc_12x_overview_image_dataset/stitchedwelloverviewimagepath/05080558_3500003720_10X_20191220_D3.czi'. Try not setting use_aicspylibczi?`