### PR TITLE
24: Continue Python 3.9 support

### DIFF
--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -84,7 +84,11 @@ class Reader(BaseReader):
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
         if not isinstance(fs, LocalFileSystem):
-            return False
+            raise exceptions.UnsupportedFileFormatError(
+                "bioio-czi[aicspylibczi mode]",
+                path,
+                "Try not setting use_aicspylibczi?",
+            )
         try:
             with fs.open(path) as open_resource:
                 CziFile(open_resource.f)

--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -83,17 +83,12 @@ class Reader(BaseReader):
 
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
+        if not isinstance(fs, LocalFileSystem):
+            return False
         try:
-            if not isinstance(fs, LocalFileSystem):
-                raise ValueError(
-                    f"Cannot read CZIs from non-local file system. "
-                    f"Received URI: {path}, which points to {type(fs)}."
-                )
-
             with fs.open(path) as open_resource:
                 CziFile(open_resource.f)
                 return True
-
         except RuntimeError:
             return False
 
@@ -131,9 +126,10 @@ class Reader(BaseReader):
 
         # Catch non-local file system
         if not isinstance(self._fs, LocalFileSystem):
-            raise ValueError(
-                f"Cannot read CZIs from non-local file system. "
-                f"Received URI: {self._path}, which points to {type(self._fs)}."
+            raise exceptions.UnsupportedFileFormatError(
+                "bioio-czi[aicspylibczi mode]",
+                self._path,
+                "Try not setting use_aicspylibczi?",
             )
 
         # Store params

--- a/bioio_czi/pixel_sizes.py
+++ b/bioio_czi/pixel_sizes.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from xml.etree import ElementTree as ET
 
 from bioio_base.types import PhysicalPixelSizes
@@ -18,7 +19,7 @@ def get_physical_pixel_sizes(metadata: ET.Element) -> PhysicalPixelSizes:
 
 def _single_physical_pixel_size(
     metadata: ET.Element, dimension: str, allow_none: bool = False
-) -> float | None:
+) -> Optional[float]:
     """
     Look up physical pixel size for one dimension.
     """

--- a/bioio_czi/pylibczirw_reader/reader.py
+++ b/bioio_czi/pylibczirw_reader/reader.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from typing import Any, Callable, ContextManager, Dict, Optional, Tuple
+from typing import Any, Callable, ContextManager, Dict, Optional, Tuple, Union
 from xml.etree import ElementTree as ET
 
 import dask.array as da
@@ -155,7 +155,7 @@ class Reader(BaseReader):
 
     def _get_coords(
         self, xml: ET.Element, scene_index: int, dims_shape: Dict[str, Any]
-    ) -> Dict[str, list | np.ndarray]:
+    ) -> Dict[str, Union[list, np.ndarray]]:
         """
         Generate coordinate arrays for channel dimension ("C") and spatial dimensions
         ("X", "Y", and "Z") based on channel names and physical pixel sizes.

--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -99,7 +99,6 @@ class Reader(BaseReader):
             Any specific keyword arguments to pass to the fsspec-created filesystem.
             Default: {}
         """
-        # TODO handle case where "wrong" reader is called
         if use_aicspylibczi:
             self._implementation = AicsPyLibCziReader(image, **kwargs)
         else:

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -198,10 +198,16 @@ def test_czi_reader(
     )
 
 
-@pytest.mark.xfail(reason="Do no support remote CZI reading yet")
+@pytest.mark.xfail(
+    raises=exceptions.UnsupportedFileFormatError,
+    reason="Do no support remote CZI reading in aicspylibczi mode",
+)
 def test_czi_reader_remote_xfail() -> None:
     # Construct full filepath
-    uri = LOCAL_RESOURCES_DIR / "s_1_t_1_c_1_z_1.czi"
+    uri = (
+        "https://allencell.s3.amazonaws.com/aics/hipsc_12x_overview_image_dataset/"
+        "stitchedwelloverviewimagepath/05080558_3500003720_10X_20191220_D3.czi"
+    )
     Reader(uri, use_aicspylibczi=True)
 
 

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -200,7 +200,7 @@ def test_czi_reader(
 
 @pytest.mark.xfail(
     raises=exceptions.UnsupportedFileFormatError,
-    reason="Do no support remote CZI reading in aicspylibczi mode",
+    reason="Do not support remote CZI reading in aicspylibczi mode",
 )
 def test_czi_reader_remote_xfail() -> None:
     # Construct full filepath


### PR DESCRIPTION
Some of my changes for #24 started using language features not available in Python 3.9 because I thought we were dropping support for Python 3.9. However, I realized that only `bioio`, not `bioio-base`, removes support for Python 3.9, so this plugin can continue supporting 3.9.

# Testing
Results in CI: https://github.com/bioio-devs/bioio-czi/actions/runs/14230360351