### PR TITLE
feature/additional-metadata-2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,4 +29,6 @@ repos:
     rev: v1.4.1
     hooks:
       - id: mypy
-        additional_dependencies: [types-PyYAML>=6.0.12.9]
+        additional_dependencies:
+          - types-PyYAML>=6.0.12.9
+          - types-python-dateutil

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The primary difference is that `pylibczirw` supports reading CZIs over the inter
 
 *Elapsed time metadata include the following. These are derived from individual subblock metadata.
 * `BioImage(...).time_interval`
-* `BioImage(...).standard_metadata.get["Timelapse Interval"]`
-* `BioImage(...).standard_metadata.get["Total Time Duration"]`
+* `BioImage(...).standard_metadata.timelapse_interval`
+* `BioImage(...).standard_metadata.total_time_duration`
 
 ## Example Usage (see full documentation for more examples)
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,15 @@ Install bioio-czi alongside bioio:
 | Read CZIs from the internet | ✅ | ❌ |
 | Read single tile from tiled CZI | ❌ | ✅ |
 | Read single tile's metadata from tiled CZI | ❌ | ✅ |
+| Read elapsed time metadata* | ❌ | ✅ |
 | Read stitched mosaic of a tiled CZI | ✅ | ✅ |
 
 The primary difference is that `pylibczirw` supports reading CZIs over the internet but cannot access individual tiles from a tiled CZI. To use `aicspylibczi`, add the `use_aicspylibczi=True` parameter when creating a reader. For example: `from bioio import BioImage; img = BioImage(..., use_aicspylibczi=True)`.
+
+*Elapsed time metadata include the following. These are derived from individual subblock metadata.
+* `BioImage(...).time_interval`
+* `BioImage(...).standard_metadata.get["Timelapse Interval"]`
+* `BioImage(...).standard_metadata.get["Total Time Duration"]`
 
 ## Example Usage (see full documentation for more examples)
 

--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import datetime
 import logging
 import xml.etree.ElementTree as ET
 from copy import copy
 from pathlib import Path
 from typing import Any, Dict, Hashable, List, Optional, Tuple, Union
+from zoneinfo import ZoneInfo
 
 import dask.array as da
 import numpy as np
@@ -22,9 +24,13 @@ from bioio_base.dimensions import (
     Dimensions,
 )
 from bioio_base.reader import Reader as BaseReader
+from bioio_base.standard_metadata import StandardMetadata
 from dask import delayed
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
+from lxml import etree
+from lxml.etree import XML, _Element
+from ome_types.model import OME
 
 from .. import metadata as metadata_utils
 from ..bounding_box import size
@@ -54,6 +60,21 @@ PIXEL_DICT = {
     "invalid": np.uint8,
 }
 
+
+###############################################################################
+
+OME_NS = {"": "http://www.openmicroscopy.org/Schemas/OME/2016-06"}
+
+EXTRACTED_OBJECTIVE_VALUES_TO_VALID_OBJECTIVE_VALUES = {
+    "63x/1.2W": "63x/1.2W",
+    "20x/0.8": "20x/0.80",
+    "40x/1.2W": "40x/1.2W",
+    "100x/1.25W": "100x/1.25W",
+    "100x/1.46Oil": "100x/1.46Oil",
+    "44.83x/1.0W": "44.83x/1.0W",
+    "5x/0.12": "5x/0.12",
+    "10x/0.45": "10x/0.45",
+}
 
 ###############################################################################
 
@@ -958,3 +979,363 @@ class Reader(BaseReader):
                 m_indexes_to_mosaic_positions[m_index]
                 for m_index in sorted(m_indexes_to_mosaic_positions.keys())
             ]
+
+    @property
+    def ome_metadata(self) -> OME:
+        return metadata_utils.transform_metadata_with_xslt(
+            self.metadata,
+            Path(__file__).parent.parent / "czi-to-ome-xslt/xslt/czi-to-ome.xsl",
+        )
+
+    def _get_metadata_element(self, path: str) -> Optional[_Element]:
+        """Gets the first occurrence of the given XML path if one exists."""
+        xml = XML(self.ome_metadata.to_xml())
+        return xml.find(path, OME_NS)
+
+    def _extract_acquisition_time_from_subblock_metadata(
+        self, subblock_metadata: list
+    ) -> Optional[datetime.datetime]:
+        """Extracts acquisition time from subblock metadata."""
+        if not subblock_metadata:
+            return None
+
+        metablock_of_subblock = subblock_metadata[0][1]
+        outlxml = etree.fromstring(metablock_of_subblock)
+        acquisition_time_element = outlxml.find(".//AcquisitionTime")
+
+        if acquisition_time_element is not None and acquisition_time_element.text:
+            try:
+                acquisition_time_from_czi_xml = acquisition_time_element.text
+                acquisition_time_as_date = datetime.datetime.strptime(
+                    acquisition_time_from_czi_xml.split(".")[0], "%Y-%m-%dT%H:%M:%S"
+                )
+
+                formatted_acquisition_time = (
+                    acquisition_time_as_date
+                    + datetime.timedelta(
+                        microseconds=int(
+                            str(acquisition_time_from_czi_xml).split(".")[1][:-1]
+                        )
+                        / 1000
+                    )
+                )
+
+                return formatted_acquisition_time
+            except Exception as exc:
+                log.warning(
+                    "Failed to extract acquisition time: %s", exc, exc_info=True
+                )
+
+        return None
+
+    @property
+    def imaging_date(self) -> Optional[str]:
+        """
+        Extracts the acquisition date from the OME metadata.
+        Returns
+        -------
+        Optional[str]
+            The acquisition date in ISO format (YYYY-MM-DD) adjusted to Pacific Time.
+            Returns None if the acquisition date is not found or cannot be parsed.
+        """
+        try:
+            el = self._get_metadata_element("./Image/AcquisitionDate")
+            if el is not None and el.text:
+                # Convert from ISO 8601 (e.g., "2025-03-31T12:00:00Z") to datetime
+                utc_time = datetime.datetime.fromisoformat(
+                    el.text.replace("Z", "+00:00")
+                )
+                pacific_time = utc_time.astimezone(ZoneInfo("America/Los_Angeles"))
+                return pacific_time.date().isoformat()
+        except ValueError as exc:
+            log.warning("Failed to parse Acquisition Date: %s", exc, exc_info=True)
+        except Exception as exc:
+            log.warning("Failed to extract Acquisition Date: %s", exc, exc_info=True)
+
+        return None
+
+    @property
+    def binning(self) -> Optional[str]:
+        """
+        Extracts the binning setting from the OME metadata.
+        Returns
+        -------
+        Optional[str]
+            The binning setting as a string. Returns None if not found.
+        """
+        try:
+            el = self._get_metadata_element("./Image/Pixels/Channel/DetectorSettings")
+            if el is not None:
+                return el.get("Binning", None)
+        except Exception as exc:
+            log.warning("Failed to extract Binning setting: %s", exc, exc_info=True)
+
+        return None
+
+    @property
+    def imaged_by(self) -> Optional[str]:
+        """
+        Extracts the name of the experimenter (user who imaged the sample).
+        Returns
+        -------
+        Optional[str]
+            The username of the experimenter. Returns None if not found.
+        """
+        try:
+            el = self._get_metadata_element("./Experimenter")
+            if el is not None:
+                return el.get("UserName", None)
+        except Exception as exc:
+            log.warning("Failed to extract Imaged By: %s", exc, exc_info=True)
+
+        return None
+
+    @property
+    def objective(self) -> Optional[str]:
+        """
+        Extracts the microscope objective details.
+        Returns
+        -------
+        Optional[str]
+            The formatted objective magnification and numerical aperture.
+            Returns None if not found.
+        """
+        try:
+            el = self._get_metadata_element("./Instrument/Objective")
+            if el is not None:
+                nominal_magnification = el.get("NominalMagnification")
+                lens_na = el.get("LensNA")
+                immersion = el.get("Immersion")
+
+                if immersion == "Oil":
+                    immersion_suffix = "Oil"
+                elif immersion == "Water":
+                    immersion_suffix = "W"
+                else:
+                    immersion_suffix = ""
+
+                if nominal_magnification is not None and lens_na is not None:
+                    raw_objective = (
+                        f"{round(float(nominal_magnification))}x/"
+                        f"{float(lens_na)}{immersion_suffix}"
+                    )
+
+                    if (
+                        raw_objective
+                        in EXTRACTED_OBJECTIVE_VALUES_TO_VALID_OBJECTIVE_VALUES.values()
+                    ):
+                        return raw_objective
+
+                    for (
+                        raw_objective_value
+                    ) in EXTRACTED_OBJECTIVE_VALUES_TO_VALID_OBJECTIVE_VALUES.keys():
+                        if raw_objective in raw_objective_value:
+                            return EXTRACTED_OBJECTIVE_VALUES_TO_VALID_OBJECTIVE_VALUES[
+                                raw_objective_value
+                            ]
+        except Exception as exc:
+            log.warning("Failed to extract Objective: %s", exc, exc_info=True)
+
+        return None
+
+    @property
+    def time_interval(self) -> types.TimeInterval:
+        """
+        Extracts the time interval between the first two time points in milliseconds.
+        Returns
+        -------
+        Optional[int]
+            Timelapse interval in milliseconds. Returns None if extraction fails.
+        """
+        try:
+            with self._fs.open(self._path) as open_resource:
+                czi = CziFile(open_resource.f)
+
+                # Get acquisition time of first subblock (T=0)
+                metadata_of_first_subblock = czi.read_subblock_metadata(
+                    Z=0, C=0, T=0, R=0, S=0, I=0, H=0, V=0
+                )
+                acquisition_time_of_first_subblock = (
+                    self._extract_acquisition_time_from_subblock_metadata(
+                        metadata_of_first_subblock
+                    )
+                )
+
+                # Get acquisition time of second subblock (T=1)
+                metadata_of_second_subblock = czi.read_subblock_metadata(
+                    Z=0, C=0, T=1, R=0, S=0, I=0, H=0, V=0
+                )
+                acquisition_time_of_second_subblock = (
+                    self._extract_acquisition_time_from_subblock_metadata(
+                        metadata_of_second_subblock
+                    )
+                )
+
+                if (
+                    acquisition_time_of_first_subblock
+                    and acquisition_time_of_second_subblock
+                ):
+                    delta = (
+                        acquisition_time_of_second_subblock
+                        - acquisition_time_of_first_subblock
+                    )
+                    return round(delta.total_seconds(), 0) * 1000
+
+        except Exception as exc:
+            log.warning("Failed to extract Timelapse Interval: %s", exc, exc_info=True)
+
+        return None
+
+    @property
+    def total_time_duration(self) -> Optional[int]:
+        """
+        Extracts the total duration of the timelapse in milliseconds.
+        Returns
+        -------
+        Optional[int]
+            Total time duration in milliseconds. Returns None if extraction fails.
+        """
+        try:
+            with self._fs.open(self._path) as open_resource:
+                czi = CziFile(open_resource.f)
+
+                # Get the number of time points (SizeT)
+                size_t_element = czi.meta.find(".//SizeT")
+                if size_t_element is None or not size_t_element.text:
+                    return None
+
+                last_timepoint = int(size_t_element.text) - 1
+
+                # Get acquisition time of first subblock (T=0)
+                metadata_of_first_subblock = czi.read_subblock_metadata(
+                    Z=0, C=0, T=0, R=0, S=0, I=0, H=0, V=0
+                )
+                acquisition_time_of_first_subblock = (
+                    self._extract_acquisition_time_from_subblock_metadata(
+                        metadata_of_first_subblock
+                    )
+                )
+
+                # Get acquisition time of last subblock (T=last_timepoint)
+                metadata_of_last_subblock = czi.read_subblock_metadata(
+                    Z=0, C=0, T=last_timepoint, R=0, S=0, I=0, H=0, V=0
+                )
+                acquisition_time_of_last_subblock = (
+                    self._extract_acquisition_time_from_subblock_metadata(
+                        metadata_of_last_subblock
+                    )
+                )
+
+                if (
+                    acquisition_time_of_first_subblock
+                    and acquisition_time_of_last_subblock
+                ):
+                    delta = (
+                        acquisition_time_of_last_subblock
+                        - acquisition_time_of_first_subblock
+                    )
+                    return int(
+                        round(delta.total_seconds(), 0) * 1000
+                    )  # Convert to milliseconds
+
+        except Exception as exc:
+            log.warning("Failed to extract Total Time Duration: %s", exc, exc_info=True)
+
+        return None
+
+    @property
+    def row(self) -> Optional[str]:
+        """
+        Extracts the well row index for the current scene.
+        Returns
+        -------
+        Optional[str]
+            The row index as a string. Returns None if not found.
+        """
+        try:
+            scenes = self.metadata.findall(
+                "Metadata/Information/Image/Dimensions/S/Scenes/Scene"
+            )
+            for scene in scenes:
+                if int(scene.get("Index")) == self.current_scene_index:
+                    shape = scene.find("Shape")
+                    if shape is not None:
+                        row = shape.find("RowIndex")
+                        if row is not None:
+                            return row.text
+        except Exception as exc:
+            log.warning("Failed to extract well row index: %s", exc, exc_info=True)
+
+        return None
+
+    @property
+    def column(self) -> Optional[str]:
+        """
+        Extracts the well column index for the current scene.
+        Returns
+        -------
+        Optional[str]
+            The column index as a string. Returns None if not found.
+        """
+        try:
+            scenes = self.metadata.findall(
+                "Metadata/Information/Image/Dimensions/S/Scenes/Scene"
+            )
+            for scene in scenes:
+                if int(scene.get("Index")) == self.current_scene_index:
+                    shape = scene.find("Shape")
+                    if shape is not None:
+                        col = shape.find("ColumnIndex")
+                        if col is not None:
+                            return col.text
+        except Exception as exc:
+            log.warning("Failed to extract well column index: %s", exc, exc_info=True)
+
+        return None
+
+    @property
+    def position_index(self) -> Optional[int]:
+        """
+        Extracts the numeric position index from the current scene name.
+        Returns
+        -------
+        Optional[int]
+            The numeric part of the scene name.
+            Returns None if parsing fails.
+        """
+        try:
+            scene_name = self.scenes[self.current_scene_index]
+            # Use only the first part before a "-" if present
+            prefix = scene_name.split("-")[0]
+            return int(prefix[1:])
+        except (IndexError, ValueError) as exc:
+            log.warning(
+                "Failed to parse position index from scene name '%s': %s",
+                scene_name,
+                exc,
+                exc_info=True,
+            )
+        except Exception as exc:
+            log.warning(
+                "Unexpected error parsing position index: %s", exc, exc_info=True
+            )
+
+        return None
+
+    @property
+    def standard_metadata(self) -> StandardMetadata:
+        """
+        Return the standard metadata for this reader, updating specific fields.
+        This implementation calls the base reader’s standard_metadata property
+        via super() and then assigns the new values.
+        """
+        metadata = super().standard_metadata
+        metadata.binning = self.binning
+        metadata.column = self.column
+        metadata.imaged_by = self.imaged_by
+        metadata.imaging_date = self.imaging_date
+        metadata.objective = self.objective
+        metadata.position_index = self.position_index
+        metadata.row = self.row
+        metadata.total_time_duration = self.total_time_duration
+        return metadata

--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -65,16 +65,16 @@ PIXEL_DICT = {
 
 OME_NS = {"": "http://www.openmicroscopy.org/Schemas/OME/2016-06"}
 
-EXTRACTED_OBJECTIVE_VALUES_TO_VALID_OBJECTIVE_VALUES = {
-    "63x/1.2W": "63x/1.2W",
-    "20x/0.8": "20x/0.80",
-    "40x/1.2W": "40x/1.2W",
-    "100x/1.25W": "100x/1.25W",
-    "100x/1.46Oil": "100x/1.46Oil",
-    "44.83x/1.0W": "44.83x/1.0W",
-    "5x/0.12": "5x/0.12",
-    "10x/0.45": "10x/0.45",
-}
+VALID_OBJECTIVES = [
+    "63x/1.2W",
+    "20x/0.8",
+    "40x/1.2W",
+    "100x/1.25W",
+    "100x/1.46Oil",
+    "44.83x/1.0W",
+    "5x/0.12",
+    "10x/0.45",
+]
 
 ###############################################################################
 
@@ -1094,6 +1094,7 @@ class Reader(BaseReader):
     def objective(self) -> Optional[str]:
         """
         Extracts the microscope objective details.
+
         Returns
         -------
         Optional[str]
@@ -1107,12 +1108,12 @@ class Reader(BaseReader):
                 lens_na = el.get("LensNA")
                 immersion = el.get("Immersion")
 
+                # Determine the immersion suffix.
+                immersion_suffix = ""
                 if immersion == "Oil":
                     immersion_suffix = "Oil"
                 elif immersion == "Water":
                     immersion_suffix = "W"
-                else:
-                    immersion_suffix = ""
 
                 if nominal_magnification is not None and lens_na is not None:
                     raw_objective = (
@@ -1120,19 +1121,14 @@ class Reader(BaseReader):
                         f"{float(lens_na)}{immersion_suffix}"
                     )
 
-                    if (
-                        raw_objective
-                        in EXTRACTED_OBJECTIVE_VALUES_TO_VALID_OBJECTIVE_VALUES.values()
-                    ):
+                    # Check if the raw objective matches one of the valid values.
+                    if raw_objective in VALID_OBJECTIVES:
                         return raw_objective
 
-                    for (
-                        raw_objective_value
-                    ) in EXTRACTED_OBJECTIVE_VALUES_TO_VALID_OBJECTIVE_VALUES.keys():
-                        if raw_objective in raw_objective_value:
-                            return EXTRACTED_OBJECTIVE_VALUES_TO_VALID_OBJECTIVE_VALUES[
-                                raw_objective_value
-                            ]
+                    # Otherwise, check if roughly raw_objective.
+                    for valid in VALID_OBJECTIVES:
+                        if raw_objective in valid:
+                            return valid
         except Exception as exc:
             log.warning("Failed to extract Objective: %s", exc, exc_info=True)
 

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -24,17 +24,7 @@ def _extract_acquisition_time_from_subblock_metadata(
 
     if acquisition_time_element is not None and acquisition_time_element.text:
         try:
-            acquisition_time_from_czi_xml = acquisition_time_element.text
-            acquisition_time_as_date = datetime.datetime.strptime(
-                acquisition_time_from_czi_xml.split(".")[0], "%Y-%m-%dT%H:%M:%S"
-            )
-
-            formatted_acquisition_time = acquisition_time_as_date + datetime.timedelta(
-                microseconds=int(str(acquisition_time_from_czi_xml).split(".")[1][:-1])
-                / 1000
-            )
-
-            return formatted_acquisition_time
+            return datetime.datetime.fromisoformat(str(acquisition_time_element.text))
         except Exception as exc:
             log.warning("Failed to extract acquisition time: %s", exc, exc_info=True)
 

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -53,7 +53,7 @@ def time_between_subblocks(
 
     if start_time is not None and end_time is not None:
         delta = end_time - start_time
-        ms: int = round(delta.total_seconds()) * 1000
-        return ms
+        milliseconds: int = round(delta.total_seconds()) * 1000
+        return milliseconds
 
     return None

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -1,0 +1,37 @@
+import datetime
+import logging
+from typing import Optional
+
+from lxml import etree
+
+log = logging.getLogger(__name__)
+
+
+def extract_acquisition_time_from_subblock_metadata(
+    subblock_metadata: list[tuple[dict, str]]
+) -> Optional[datetime.datetime]:
+    """Extracts acquisition time from subblock metadata."""
+    if not subblock_metadata:
+        return None
+
+    metablock_of_subblock = subblock_metadata[0][1]
+    outlxml = etree.fromstring(metablock_of_subblock)
+    acquisition_time_element = outlxml.find(".//AcquisitionTime")
+
+    if acquisition_time_element is not None and acquisition_time_element.text:
+        try:
+            acquisition_time_from_czi_xml = acquisition_time_element.text
+            acquisition_time_as_date = datetime.datetime.strptime(
+                acquisition_time_from_czi_xml.split(".")[0], "%Y-%m-%dT%H:%M:%S"
+            )
+
+            formatted_acquisition_time = acquisition_time_as_date + datetime.timedelta(
+                microseconds=int(str(acquisition_time_from_czi_xml).split(".")[1][:-1])
+                / 1000
+            )
+
+            return formatted_acquisition_time
+        except Exception as exc:
+            log.warning("Failed to extract acquisition time: %s", exc, exc_info=True)
+
+    return None

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -40,7 +40,7 @@ def _acquisition_time(czi: CziFile, which_subblock: int) -> Optional[datetime.da
 
 def time_between_subblocks(
     czi: CziFile, start_subblock_index: int, end_subblock_index: int
-) -> Optional[int]:
+) -> Optional[float]:
     """Calculates the time between two subblocks in milliseconds."""
     start_time = _acquisition_time(czi, start_subblock_index)
     end_time = _acquisition_time(czi, end_subblock_index)
@@ -50,7 +50,6 @@ def time_between_subblocks(
         # Difference in milliseconds is delta divided by 1 millisecond
         # This method is recommended by the documentation.
         # https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds
-        milliseconds = delta / datetime.timedelta(milliseconds=1)
-        return round(milliseconds)
+        return delta / datetime.timedelta(milliseconds=1)
 
     return None

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -47,7 +47,10 @@ def time_between_subblocks(
 
     if start_time is not None and end_time is not None:
         delta = end_time - start_time
-        milliseconds: int = round(delta.total_seconds()) * 1000
-        return milliseconds
+        # Difference in milliseconds is delta divided by 1 millisecond
+        # This method is recommended by the documentation.
+        # https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds
+        milliseconds = delta / datetime.timedelta(milliseconds=1)
+        return round(milliseconds)
 
     return None

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -1,3 +1,6 @@
+"""
+Helper functions extracting metadata from subblocks in aicspylibczi mode.
+"""
 import datetime
 import logging
 from typing import Optional
@@ -8,7 +11,7 @@ from lxml import etree
 log = logging.getLogger(__name__)
 
 
-def extract_acquisition_time_from_subblock_metadata(
+def _extract_acquisition_time_from_subblock_metadata(
     subblock_metadata: list[tuple[dict, str]]
 ) -> Optional[datetime.datetime]:
     """Extracts acquisition time from subblock metadata."""
@@ -38,18 +41,19 @@ def extract_acquisition_time_from_subblock_metadata(
     return None
 
 
-def acquisition_time(czi: CziFile, which_subblock: int) -> Optional[datetime.datetime]:
+def _acquisition_time(czi: CziFile, which_subblock: int) -> Optional[datetime.datetime]:
     subblock_metadata = czi.read_subblock_metadata(
         Z=0, C=0, T=which_subblock, R=0, S=0, I=0, H=0, V=0
     )
-    return extract_acquisition_time_from_subblock_metadata(subblock_metadata)
+    return _extract_acquisition_time_from_subblock_metadata(subblock_metadata)
 
 
 def time_between_subblocks(
     czi: CziFile, start_subblock_index: int, end_subblock_index: int
 ) -> Optional[int]:
-    start_time = acquisition_time(czi, start_subblock_index)
-    end_time = acquisition_time(czi, end_subblock_index)
+    """Calculates the time between two subblocks in milliseconds."""
+    start_time = _acquisition_time(czi, start_subblock_index)
+    end_time = _acquisition_time(czi, end_subblock_index)
 
     if start_time is not None and end_time is not None:
         delta = end_time - start_time

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -6,6 +6,7 @@ import logging
 from typing import Optional
 
 from aicspylibczi import CziFile
+from dateutil import parser
 from lxml import etree
 
 log = logging.getLogger(__name__)
@@ -24,7 +25,10 @@ def _extract_acquisition_time_from_subblock_metadata(
 
     if acquisition_time_element is not None and acquisition_time_element.text:
         try:
-            return datetime.datetime.fromisoformat(str(acquisition_time_element.text))
+            # For Python 3.11+, the builtin datetime is sufficient. If we drop support
+            # for 3.10, use datetime.datetime.fromisoformat instead of
+            # dateutil.parser.isoparse.
+            return parser.isoparse(str(acquisition_time_element.text))
         except Exception as exc:
             log.warning("Failed to extract acquisition time: %s", exc, exc_info=True)
 

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 from typing import Optional
 
+from aicspylibczi import CziFile
 from lxml import etree
 
 log = logging.getLogger(__name__)
@@ -33,5 +34,26 @@ def extract_acquisition_time_from_subblock_metadata(
             return formatted_acquisition_time
         except Exception as exc:
             log.warning("Failed to extract acquisition time: %s", exc, exc_info=True)
+
+    return None
+
+
+def acquisition_time(czi: CziFile, which_subblock: int) -> Optional[datetime.datetime]:
+    subblock_metadata = czi.read_subblock_metadata(
+        Z=0, C=0, T=which_subblock, R=0, S=0, I=0, H=0, V=0
+    )
+    return extract_acquisition_time_from_subblock_metadata(subblock_metadata)
+
+
+def time_between_subblocks(
+    czi: CziFile, start_subblock_index: int, end_subblock_index: int
+) -> Optional[int]:
+    start_time = acquisition_time(czi, start_subblock_index)
+    end_time = acquisition_time(czi, end_subblock_index)
+
+    if start_time is not None and end_time is not None:
+        delta = end_time - start_time
+        ms: int = round(delta.total_seconds()) * 1000
+        return ms
 
     return None

--- a/bioio_czi/metadata.py
+++ b/bioio_czi/metadata.py
@@ -1,11 +1,14 @@
 import os
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 from xml.etree import ElementTree as ET
 
 import lxml.etree
 from bioio_base.types import PathLike
+from lxml.etree import XML, _Element
 from ome_types import OME
+
+OME_NS = {"": "http://www.openmicroscopy.org/Schemas/OME/2016-06"}
 
 
 class UnsupportedMetadataError(Exception):
@@ -79,6 +82,12 @@ def generate_ome_instrument_id(instrument_id: Union[str, int]) -> str:
         The OME standard for instrument IDs.
     """
     return f"Instrument:{instrument_id}"
+
+
+def get_metadata_element(ome_metadata: OME, path: str) -> Optional[_Element]:
+    """Gets the first occurrence of the given XML path if one exists."""
+    xml = XML(ome_metadata.to_xml())
+    return xml.find(path, OME_NS)
 
 
 def generate_ome_detector_id(detector_id: Union[str, int]) -> str:

--- a/bioio_czi/pylibczirw_reader/reader.py
+++ b/bioio_czi/pylibczirw_reader/reader.py
@@ -430,6 +430,13 @@ class Reader(BaseReader):
         """
         return None
 
+    @property
+    def total_time_duration(self) -> None:
+        """
+        Cannot read time duration accurately without subblock metadata.
+        """
+        return None
+
 
 def open(filepath: str) -> ContextManager[czi.CziReader]:
     """

--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -364,7 +364,14 @@ class Reader(BaseReader):
         This implementation calls the base reader's standard_metadata property
         via super() and then assigns the new values.
         """
+        # 1. Some of the standard metadata can be read from all bioio Readers in the
+        # same way, which the following super() call does. For instance,
+        # standard_metadata.timelapse_interval is set to self.time_interval.
         metadata = super().standard_metadata
+
+        # 2. Most of the remaining implementation is identical across pylibczirw and
+        # aicspylibczi modes, so it is shared here. The self-contained standard_metadata
+        # module holds the implementation for extracting these from the metadata.
         metadata.binning = standard_metadata.binning(self.ome_metadata)
         metadata.column = standard_metadata.column(
             self.metadata, self.current_scene_index
@@ -374,6 +381,9 @@ class Reader(BaseReader):
         metadata.objective = standard_metadata.objective(self.ome_metadata)
         metadata.position_index = standard_metadata.position_index(self.current_scene)
         metadata.row = standard_metadata.row(self.metadata, self.current_scene_index)
+
+        # 3. Finally, total_time_duration is mode-specific, as only aicspylibczi mode
+        # has access to the necessary subblock metadata.
         metadata.total_time_duration = self._implementation.total_time_duration
 
         return metadata

--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -8,9 +8,10 @@ from xml.etree import ElementTree
 import xarray as xr
 from bioio_base.dimensions import Dimensions
 from bioio_base.reader import Reader as BaseReader
+from bioio_base.standard_metadata import StandardMetadata
 from bioio_base.types import PathLike, PhysicalPixelSizes
 from fsspec import AbstractFileSystem
-from ome_types.model.ome import OME
+from ome_types.model import OME
 
 from bioio_czi.aicspylibczi_reader.reader import Reader as AicsPyLibCziReader
 from bioio_czi.pylibczirw_reader.reader import Reader as PylibCziReader
@@ -343,3 +344,12 @@ class Reader(BaseReader):
             The image has no mosaic dimension available.
         """
         return self._implementation.get_mosaic_tile_positions(**kwargs)
+
+    @property
+    def standard_metadata(self) -> StandardMetadata:
+        """
+        Return the standard metadata for this reader, updating specific fields.
+        This implementation calls the base reader’s standard_metadata property
+        via super() and then assigns the new values.
+        """
+        return self._implementation.standard_metadata

--- a/bioio_czi/standard_metadata.py
+++ b/bioio_czi/standard_metadata.py
@@ -1,0 +1,206 @@
+import logging
+from datetime import datetime
+from typing import Optional
+from xml.etree.ElementTree import Element
+from zoneinfo import ZoneInfo
+
+from ome_types import OME
+
+from bioio_czi.metadata import get_metadata_element
+
+log = logging.getLogger(__name__)
+
+VALID_OBJECTIVES = [
+    "63x/1.2W",
+    "20x/0.8",
+    "40x/1.2W",
+    "100x/1.25W",
+    "100x/1.46Oil",
+    "44.83x/1.0W",
+    "5x/0.12",
+    "10x/0.45",
+]
+
+
+def binning(ome_metadata: OME) -> Optional[str]:
+    """
+    Extracts the binning setting from the OME metadata.
+    Returns
+    -------
+    Optional[str]
+        The binning setting as a string. Returns None if not found.
+    """
+    try:
+        el = get_metadata_element(
+            ome_metadata, "./Image/Pixels/Channel/DetectorSettings"
+        )
+        if el is not None:
+            return el.get("Binning", None)
+    except Exception as exc:
+        log.warning("Failed to extract Binning setting: %s", exc, exc_info=True)
+
+    return None
+
+
+def column(metadata: Element, current_scene_index: int) -> Optional[str]:
+    """
+    Extracts the well column index for the current scene.
+    Returns
+    -------
+    Optional[str]
+        The column index as a string. Returns None if not found.
+    """
+    try:
+        scenes = metadata.findall(
+            "Metadata/Information/Image/Dimensions/S/Scenes/Scene"
+        )
+        for scene in scenes:
+            index = scene.get("Index")
+            if index is not None and int(index) == current_scene_index:
+                shape = scene.find("Shape")
+                if shape is not None:
+                    col = shape.find("ColumnIndex")
+                    if col is not None:
+                        return col.text
+    except Exception as exc:
+        log.warning("Failed to extract well column index: %s", exc, exc_info=True)
+
+    return None
+
+
+def imaged_by(ome_metadata: OME) -> Optional[str]:
+    """
+    Extracts the name of the experimenter (user who imaged the sample).
+    Returns
+    -------
+    Optional[str]
+        The username of the experimenter. Returns None if not found.
+    """
+    try:
+        el = get_metadata_element(ome_metadata, "./Experimenter")
+        if el is not None:
+            return el.get("UserName", None)
+    except Exception as exc:
+        log.warning("Failed to extract Imaged By: %s", exc, exc_info=True)
+
+    return None
+
+
+def imaging_date(ome_metadata: OME) -> Optional[str]:
+    """
+    Extracts the acquisition date from the OME metadata.
+    Returns
+    -------
+    Optional[str]
+        The acquisition date in ISO format (YYYY-MM-DD) adjusted to Pacific Time.
+        Returns None if the acquisition date is not found or cannot be parsed.
+    """
+    try:
+        el = get_metadata_element(ome_metadata, "./Image/AcquisitionDate")
+        if el is not None and el.text:
+            # Convert from ISO 8601 (e.g., "2025-03-31T12:00:00Z") to datetime
+            utc_time = datetime.fromisoformat(el.text.replace("Z", "+00:00"))
+            pacific_time = utc_time.astimezone(ZoneInfo("America/Los_Angeles"))
+            return pacific_time.date().isoformat()
+    except ValueError as exc:
+        log.warning("Failed to parse Acquisition Date: %s", exc, exc_info=True)
+    except Exception as exc:
+        log.warning("Failed to extract Acquisition Date: %s", exc, exc_info=True)
+
+    return None
+
+
+def objective(ome_metadata: OME) -> Optional[str]:
+    """
+    Extracts the microscope objective details.
+
+    Returns
+    -------
+    Optional[str]
+        The formatted objective magnification and numerical aperture.
+        Returns None if not found.
+    """
+    try:
+        el = get_metadata_element(ome_metadata, "./Instrument/Objective")
+        if el is not None:
+            nominal_magnification = el.get("NominalMagnification")
+            lens_na = el.get("LensNA")
+            immersion = el.get("Immersion")
+
+            # Determine the immersion suffix.
+            immersion_suffix = ""
+            if immersion == "Oil":
+                immersion_suffix = "Oil"
+            elif immersion == "Water":
+                immersion_suffix = "W"
+
+            if nominal_magnification is not None and lens_na is not None:
+                raw_objective = (
+                    f"{round(float(nominal_magnification))}x/"
+                    f"{float(lens_na)}{immersion_suffix}"
+                )
+
+                # Check if the raw objective matches one of the valid values.
+                if raw_objective in VALID_OBJECTIVES:
+                    return raw_objective
+
+                # Otherwise, check if roughly raw_objective.
+                for valid in VALID_OBJECTIVES:
+                    if raw_objective in valid:
+                        return valid
+    except Exception as exc:
+        log.warning("Failed to extract Objective: %s", exc, exc_info=True)
+
+    return None
+
+
+def position_index(scene: str) -> Optional[int]:
+    """
+    Extracts the numeric position index from the current scene name.
+    Returns
+    -------
+    Optional[int]
+        The numeric part of the scene name.
+        Returns None if parsing fails.
+    """
+    try:
+        # Use only the first part before a "-" if present
+        prefix = scene.split("-")[0]
+        return int(prefix[1:])
+    except (IndexError, ValueError) as exc:
+        log.warning(
+            "Failed to parse position index from scene name '%s': %s",
+            scene,
+            exc,
+            exc_info=True,
+        )
+    except Exception as exc:
+        log.warning("Unexpected error parsing position index: %s", exc, exc_info=True)
+
+    return None
+
+
+def row(metadata: Element, current_scene_index: int) -> Optional[str]:
+    """
+    Extracts the well row index for the current scene.
+    Returns
+    -------
+    Optional[str]
+        The row index as a string. Returns None if not found.
+    """
+    try:
+        scenes = metadata.findall(
+            "Metadata/Information/Image/Dimensions/S/Scenes/Scene"
+        )
+        for scene in scenes:
+            index = scene.get("Index")
+            if index is not None and int(index) == current_scene_index:
+                shape = scene.find("Shape")
+                if shape is not None:
+                    row = shape.find("RowIndex")
+                    if row is not None:
+                        return row.text
+    except Exception as exc:
+        log.warning("Failed to extract well row index: %s", exc, exc_info=True)
+
+    return None

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -441,7 +441,7 @@ def test_standard_metadata() -> None:
         "Row": "4",
         "Timelapse": True,
         "Timelapse Interval": 60000.0,
-        "Total Time Duration": 60000,
+        "Total Time Duration": "60000",
     }
 
     # Compare each key's values.

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import xml.etree.ElementTree as ET
-from typing import Any, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 import pytest
@@ -415,69 +415,3 @@ def test_czi_reader_mosaic_coords(
         reader.mosaic_xarray_dask_data.coords[dimensions.DimensionNames.SpatialX].data,
         expected_mosaic_x_coords,
     )
-
-
-@pytest.mark.parametrize(
-    "filename, expected",
-    [
-        (
-            "variable_per_scene_dims.czi",
-            {
-                "Binning": "1x1",
-                "Column": "4",
-                "Dimensions Present": "TCZYX",
-                "Image Size C": 1,
-                "Image Size T": 2,
-                "Image Size X": 1848,
-                "Image Size Y": 1248,
-                "Image Size Z": 2,
-                "Imaged By": "sara.carlson",
-                "Imaging Date": "2020-01-17",
-                "Objective": "10x/0.45",
-                "Pixel Size X": 0.5416666666666666,
-                "Pixel Size Y": 0.5416666666666666,
-                "Pixel Size Z": 2.23,
-                "Position Index": 1,
-                "Row": "4",
-                "Timelapse": True,
-                "Timelapse Interval": 60000.0,
-                "Total Time Duration": "60000",
-            },
-        ),
-        (
-            "OverViewScan.czi",
-            {
-                "Binning": "Other",
-                "Column": None,
-                "Dimensions Present": "CMYX",
-                "Image Size C": 1,
-                "Image Size T": None,
-                "Image Size X": 544,
-                "Image Size Y": 440,
-                "Image Size Z": None,
-                "Imaged By": "M1SRH",
-                "Imaging Date": "2016-03-11",
-                "Objective": None,
-                "Pixel Size X": 4.5743626119409,
-                "Pixel Size Y": 4.5743626119409,
-                "Pixel Size Z": None,
-                "Position Index": None,
-                "Row": None,
-                "Timelapse": False,
-                "Timelapse Interval": 0.0,
-                "Total Time Duration": None,
-            },
-        ),
-    ],
-)
-def test_standard_metadata(filename: str, expected: dict[str, Any]) -> None:
-    uri = LOCAL_RESOURCES_DIR / filename
-    reader = Reader(uri, use_aicspylibczi=True)
-    metadata = reader.standard_metadata.to_dict()
-
-    # Compare each key's values.
-    for key, expected_value in expected.items():
-        if isinstance(expected_value, float):
-            assert metadata[key] == pytest.approx(expected_value)
-        else:
-            assert metadata[key] == expected_value

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import xml.etree.ElementTree as ET
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import numpy as np
 import pytest
@@ -417,32 +417,63 @@ def test_czi_reader_mosaic_coords(
     )
 
 
-def test_standard_metadata() -> None:
-    uri = LOCAL_RESOURCES_DIR / "variable_per_scene_dims.czi"
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        (
+            "variable_per_scene_dims.czi",
+            {
+                "Binning": "1x1",
+                "Column": "4",
+                "Dimensions Present": "TCZYX",
+                "Image Size C": 1,
+                "Image Size T": 2,
+                "Image Size X": 1848,
+                "Image Size Y": 1248,
+                "Image Size Z": 2,
+                "Imaged By": "sara.carlson",
+                "Imaging Date": "2020-01-17",
+                "Objective": "10x/0.45",
+                "Pixel Size X": 0.5416666666666666,
+                "Pixel Size Y": 0.5416666666666666,
+                "Pixel Size Z": 2.23,
+                "Position Index": 1,
+                "Row": "4",
+                "Timelapse": True,
+                "Timelapse Interval": 60000.0,
+                "Total Time Duration": "60000",
+            },
+        ),
+        (
+            "OverViewScan.czi",
+            {
+                "Binning": "Other",
+                "Column": None,
+                "Dimensions Present": "CMYX",
+                "Image Size C": 1,
+                "Image Size T": None,
+                "Image Size X": 544,
+                "Image Size Y": 440,
+                "Image Size Z": None,
+                "Imaged By": "M1SRH",
+                "Imaging Date": "2016-03-11",
+                "Objective": None,
+                "Pixel Size X": 4.5743626119409,
+                "Pixel Size Y": 4.5743626119409,
+                "Pixel Size Z": None,
+                "Position Index": None,
+                "Row": None,
+                "Timelapse": False,
+                "Timelapse Interval": 0.0,
+                "Total Time Duration": None,
+            },
+        ),
+    ],
+)
+def test_standard_metadata(filename: str, expected: dict[str, Any]) -> None:
+    uri = LOCAL_RESOURCES_DIR / filename
     reader = Reader(uri, use_aicspylibczi=True)
     metadata = reader.standard_metadata.to_dict()
-
-    expected = {
-        "Binning": "1x1",
-        "Column": "4",
-        "Dimensions Present": "TCZYX",
-        "Image Size C": 1,
-        "Image Size T": 2,
-        "Image Size X": 1848,
-        "Image Size Y": 1248,
-        "Image Size Z": 2,
-        "Imaged By": "sara.carlson",
-        "Imaging Date": "2020-01-17",
-        "Objective": "10x/0.45",
-        "Pixel Size X": 0.5416666666666666,
-        "Pixel Size Y": 0.5416666666666666,
-        "Pixel Size Z": 2.23,
-        "Position Index": 1,
-        "Row": "4",
-        "Timelapse": True,
-        "Timelapse Interval": 60000.0,
-        "Total Time Duration": "60000",
-    }
 
     # Compare each key's values.
     for key, expected_value in expected.items():

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -415,3 +415,38 @@ def test_czi_reader_mosaic_coords(
         reader.mosaic_xarray_dask_data.coords[dimensions.DimensionNames.SpatialX].data,
         expected_mosaic_x_coords,
     )
+
+
+def test_standard_metadata() -> None:
+    uri = LOCAL_RESOURCES_DIR / "variable_per_scene_dims.czi"
+    reader = Reader(uri, use_aicspylibczi=True)
+    metadata = reader.standard_metadata.to_dict()
+
+    expected = {
+        "Binning": "1x1",
+        "Column": "4",
+        "Dimensions Present": "TCZYX",
+        "Image Size C": 1,
+        "Image Size T": 2,
+        "Image Size X": 1848,
+        "Image Size Y": 1248,
+        "Image Size Z": 2,
+        "Imaged By": "sara.carlson",
+        "Imaging Date": "2020-01-17",
+        "Objective": "10x/0.45",
+        "Pixel Size X": 0.5416666666666666,
+        "Pixel Size Y": 0.5416666666666666,
+        "Pixel Size Z": 2.23,
+        "Position Index": 1,
+        "Row": "4",
+        "Timelapse": True,
+        "Timelapse Interval": 60000.0,
+        "Total Time Duration": 60000,
+    }
+
+    # Compare each key's values.
+    for key, expected_value in expected.items():
+        if isinstance(expected_value, float):
+            assert metadata[key] == pytest.approx(expected_value)
+        else:
+            assert metadata[key] == expected_value

--- a/bioio_czi/tests/test_standard_metadata.py
+++ b/bioio_czi/tests/test_standard_metadata.py
@@ -1,0 +1,131 @@
+from typing import Any
+
+import pytest
+
+from bioio_czi import Reader
+
+from .conftest import LOCAL_RESOURCES_DIR
+
+
+# Test each each of the following files in both aicspylibczi and pylibczirw modes.
+#   variable_per_scene_dims.czi
+#   OverViewScan.czi
+@pytest.mark.parametrize(
+    "use_aicspylibczi, filename, expected",
+    [
+        (
+            True,
+            "variable_per_scene_dims.czi",
+            {
+                "Binning": "1x1",
+                "Column": "4",
+                "Dimensions Present": "TCZYX",
+                "Image Size C": 1,
+                "Image Size T": 2,
+                "Image Size X": 1848,
+                "Image Size Y": 1248,
+                "Image Size Z": 2,
+                "Imaged By": "sara.carlson",
+                "Imaging Date": "2020-01-17",
+                "Objective": "10x/0.45",
+                "Pixel Size X": 0.5416666666666666,
+                "Pixel Size Y": 0.5416666666666666,
+                "Pixel Size Z": 2.23,
+                "Position Index": 1,
+                "Row": "4",
+                "Timelapse": True,
+                "Timelapse Interval": 60000.0,
+                "Total Time Duration": "60000",
+            },
+        ),
+        (
+            True,
+            "OverViewScan.czi",
+            {
+                "Binning": "Other",
+                "Column": None,
+                "Dimensions Present": "CMYX",
+                "Image Size C": 1,
+                "Image Size T": None,
+                "Image Size X": 544,
+                "Image Size Y": 440,
+                "Image Size Z": None,
+                "Imaged By": "M1SRH",
+                "Imaging Date": "2016-03-11",
+                "Objective": None,
+                "Pixel Size X": 4.5743626119409,
+                "Pixel Size Y": 4.5743626119409,
+                "Pixel Size Z": None,
+                "Position Index": None,
+                "Row": None,
+                "Timelapse": False,
+                "Timelapse Interval": 0.0,
+                "Total Time Duration": None,
+            },
+        ),
+        (
+            False,
+            "variable_per_scene_dims.czi",
+            {
+                "Binning": "1x1",
+                "Column": "4",
+                "Dimensions Present": "TCZYX",
+                "Image Size C": 1,
+                "Image Size T": 2,
+                "Image Size X": 1848,
+                "Image Size Y": 1248,
+                "Image Size Z": 2,
+                "Imaged By": "sara.carlson",
+                "Imaging Date": "2020-01-17",
+                "Objective": "10x/0.45",
+                "Pixel Size X": 0.5416666666666666,
+                "Pixel Size Y": 0.5416666666666666,
+                "Pixel Size Z": 2.23,
+                "Position Index": 1,
+                "Row": "4",
+                "Timelapse": True,
+                "Timelapse Interval": None,  # Available only in aicspylibczi mode
+                "Total Time Duration": None,  # Available only in aicspylibczi mode
+            },
+        ),
+        (
+            False,
+            "OverViewScan.czi",
+            {
+                "Binning": "Other",
+                "Column": None,
+                "Dimensions Present": "CYX",  # aicspylibczi mode has CMYX
+                "Image Size C": 1,
+                "Image Size T": None,
+                "Image Size X": 7398,  # Larger than aicspylibczi mode
+                "Image Size Y": 3212,  # Larger than aicspylibczi mode
+                "Image Size Z": None,
+                "Imaged By": "M1SRH",
+                "Imaging Date": "2016-03-11",
+                "Objective": None,
+                "Pixel Size X": 4.5743626119409,
+                "Pixel Size Y": 4.5743626119409,
+                "Pixel Size Z": None,
+                "Position Index": None,
+                "Row": None,
+                "Timelapse": False,
+                "Timelapse Interval": None,  # Available only in aicspylibczi mode
+                "Total Time Duration": None,
+            },
+        ),
+    ],
+)
+def test_standard_metadata(
+    use_aicspylibczi: bool, filename: str, expected: dict[str, Any]
+) -> None:
+    uri = LOCAL_RESOURCES_DIR / filename
+    reader = Reader(uri, use_aicspylibczi=use_aicspylibczi)
+    metadata = reader.standard_metadata.to_dict()
+
+    # Compare each key's values.
+    for key, expected_value in expected.items():
+        error_message = f"{key}: Expected: {expected_value}, Actual: {metadata[key]}"
+        if isinstance(expected_value, float):
+            assert metadata[key] == pytest.approx(expected_value), error_message
+        else:
+            assert metadata[key] == expected_value, error_message

--- a/bioio_czi/tests/test_standard_metadata.py
+++ b/bioio_czi/tests/test_standard_metadata.py
@@ -34,8 +34,8 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Position Index": 1,
                 "Row": "4",
                 "Timelapse": True,
-                "Timelapse Interval": 60000.0,
-                "Total Time Duration": "60000",
+                "Timelapse Interval": 59927.0,
+                "Total Time Duration": "59927.0",
             },
         ),
         (

--- a/bioio_czi/tests/test_standard_metadata.py
+++ b/bioio_czi/tests/test_standard_metadata.py
@@ -97,8 +97,10 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Dimensions Present": "CYX",  # aicspylibczi mode has CMYX
                 "Image Size C": 1,
                 "Image Size T": None,
-                "Image Size X": 7398,  # Larger than aicspylibczi mode
-                "Image Size Y": 3212,  # Larger than aicspylibczi mode
+                # This image is larger in X and Y when using pylibczirw mode than
+                # aicspylibczi mode because all the tiles are stitched together.
+                "Image Size X": 7398,
+                "Image Size Y": 3212,
                 "Image Size Z": None,
                 "Imaged By": "M1SRH",
                 "Imaging Date": "2016-03-11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   'lxml>=5; python_version >= "3.13"',
   "ome-types>=0.3.4",
   "pylibczirw",
+  "python-dateutil>=2.9.0.post0",
   "requests",
   "xarray>=2022.6.0",
 ]


### PR DESCRIPTION
### Description 
The purpose of this PR is to resolve #40 and  implement standard metadata properties released in bioio 1.5.0. This PR is the second rendition of this [PR](https://github.com/bioio-devs/bioio-czi/pull/34), repairing it from the recent pylibczirw library implementation. 

example:
```
image = bioio_czi.Reader(path, use_aicspylibczi=True)

image.standard_metadata.to_dict()
```
output:
```
{
 'Binning': '1x1',
 'Column': '4',
 'Dimensions Present': 'TCZYX',
 'Image Size C': 1,
 'Image Size T': 2,
 'Image Size X': 1848,
 'Image Size Y': 1248,
 'Image Size Z': 2,
 'Imaged By': 'sara.carlson',
 'Imaging Date': '2020-01-17',
 'Objective': '10x/0.45',
 'Pixel Size X': 0.5416666666666666,
 'Pixel Size Y': 0.5416666666666666,
 'Pixel Size Z': 2.23,
 'Position Index': 1,
 'Row': '4',
 'Timelapse': True,
 'Timelapse Interval': 60000.0,
 'Total Time Duration': 60000
}
```

Answering some previous questions (updates from @pgarrison)

1) ~This PR only covers metadata coverage for the `aicspylibczi` reader not for the new `pylibczirw` library. If we want to implement this in the future we need to come up with a different way to access these metadata points.~ This PR adds support in both of the plugin's modes: aicspylibczi and pylibczirw.

2) ~This PR inherently makes the standard metadata properties private since they're not accessible from the top level reader. Though users who directly implement `aicspylibczi` reader will be able to access them as public properties. I still don't really have a preference in this category, I slightly lean towards giving users as much access as possible.~ This PR makes the standard metadata properties available on the top-level reader.
