### PR TITLE
Bugfix: Support scenes with different metadata (aicspylibczi mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Install bioio-czi alongside bioio:
 | Read single tile from tiled CZI | ❌ | ✅ |
 | Read single tile's metadata from tiled CZI | ❌ | ✅ |
 | Read elapsed time metadata* | ❌ | ✅ |
+| Handle CZIs with different dimensions per scene** | ❌ | ✅ |
 | Read stitched mosaic of a tiled CZI | ✅ | ✅ |
 
 The primary difference is that `pylibczirw` supports reading CZIs over the internet but cannot access individual tiles from a tiled CZI. To use `aicspylibczi`, add the `use_aicspylibczi=True` parameter when creating a reader. For example: `from bioio import BioImage; img = BioImage(..., use_aicspylibczi=True)`.
@@ -42,6 +43,8 @@ The primary difference is that `pylibczirw` supports reading CZIs over the inter
 * `BioImage(...).time_interval`
 * `BioImage(...).standard_metadata.timelapse_interval`
 * `BioImage(...).standard_metadata.total_time_duration`
+
+**The underlying pylibczirw reader assumes that each scene has the same dimension. Files that do not meet this requirement may be read incorrectly in pylibczirw mode.
 
 ## Example Usage (see full documentation for more examples)
 

--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -158,6 +158,11 @@ class Reader(BaseReader):
 
         return self._mapped_dims
 
+    def _reset_self(self) -> None:
+        super()._reset_self()
+        self._mapped_dims = None
+        self._px_sizes = None
+
     @staticmethod
     def _fix_czi_dims(dims: str) -> str:
         return (
@@ -967,7 +972,10 @@ class Reader(BaseReader):
             with self._fs.open(self._path) as open_resource:
                 czi = CziFile(open_resource.f)
                 return time_between_subblocks(
-                    czi, start_subblock_index=0, end_subblock_index=1
+                    czi,
+                    self.current_scene_index,
+                    start_subblock_index=0,
+                    end_subblock_index=1,
                 )
 
         except Exception as exc:
@@ -998,7 +1006,10 @@ class Reader(BaseReader):
                 last_timepoint = int(size_t_element.text) - 1
 
                 duration = time_between_subblocks(
-                    czi, start_subblock_index=0, end_subblock_index=last_timepoint
+                    czi,
+                    self.current_scene_index,
+                    start_subblock_index=0,
+                    end_subblock_index=last_timepoint,
                 )
                 return str(duration) if duration is not None else None
 

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -35,19 +35,21 @@ def _extract_acquisition_time_from_subblock_metadata(
     return None
 
 
-def _acquisition_time(czi: CziFile, which_subblock: int) -> Optional[datetime.datetime]:
+def _acquisition_time(
+    czi: CziFile, scene: int, which_subblock: int
+) -> Optional[datetime.datetime]:
     subblock_metadata = czi.read_subblock_metadata(
-        Z=0, C=0, T=which_subblock, R=0, S=0, I=0, H=0, V=0
+        Z=0, C=0, T=which_subblock, R=0, S=scene, I=0, H=0, V=0
     )
     return _extract_acquisition_time_from_subblock_metadata(subblock_metadata)
 
 
 def time_between_subblocks(
-    czi: CziFile, start_subblock_index: int, end_subblock_index: int
+    czi: CziFile, current_scene: int, start_subblock_index: int, end_subblock_index: int
 ) -> Optional[float]:
     """Calculates the time between two subblocks in milliseconds."""
-    start_time = _acquisition_time(czi, start_subblock_index)
-    end_time = _acquisition_time(czi, end_subblock_index)
+    start_time = _acquisition_time(czi, current_scene, start_subblock_index)
+    end_time = _acquisition_time(czi, current_scene, end_subblock_index)
 
     if start_time is not None and end_time is not None:
         delta = end_time - start_time

--- a/bioio_czi/pylibczirw_reader/reader.py
+++ b/bioio_czi/pylibczirw_reader/reader.py
@@ -136,10 +136,14 @@ class Reader(BaseReader):
                     f"Expected 1 scene for index '{scene_index}' "
                     "but found {len(scene_info)}."
                 )
-            scene_name = scene_info[0].attrib["Name"]
-            if type(scene_name) != str:
-                # Fall back to index if name is raw bytes
-                return str(scene_index)
+            scene_name = scene_info[0].get("Name")
+            if scene_name is None:
+                scene_name = str(scene_index)
+            shape_info = scene_info[0].find("Shape")
+            if shape_info is not None:
+                shape_name = shape_info.get("Name")
+                if shape_name is not None:
+                    return f"{scene_name}-{shape_name}"
             return scene_name
 
         if self._scenes is None:

--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Union
 from xml.etree import ElementTree
 
 import xarray as xr
@@ -127,6 +127,39 @@ class Reader(BaseReader):
         >>> for i in range(len(image.scenes))
         """
         return self._implementation.scenes
+
+    def set_scene(self, scene_id: Union[str, int]) -> None:
+        """
+        Set the operating scene.
+
+        Parameters
+        ----------
+        scene_id: Union[str, int]
+            The scene id (if string) or scene index (if integer)
+            to set as the operating scene.
+
+        Raises
+        ------
+        IndexError
+            The provided scene id or index is not found in the available scene id list.
+        TypeError
+            The provided value wasn't a string (scene id) or integer (scene index).
+        """
+        # We must reset properties on the top-level reader because some high-level
+        # properties like xarray_dask_data are cached at the top level and only
+        # indirectly delegated to the implementation.
+        self._reset_self()
+        # set_scene must be delegated to the implementation because that's where the
+        # scene ID is stored.
+        self._implementation.set_scene(scene_id)
+
+    @property
+    def current_scene(self) -> str:
+        return self._implementation.current_scene
+
+    @property
+    def current_scene_index(self) -> int:
+        return self._implementation.current_scene_index
 
     def _read_delayed(self) -> xr.DataArray:
         """

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -129,6 +129,16 @@ def test_subblocks(filename: str, num_subblocks: int, acquistion_time: str) -> N
             None,
             (None, 1.0833333333333333, 1.0833333333333333),
         ),
+        (
+            "variable_per_scene_dims.czi",
+            "P2-D4",
+            ("P1-D4", "P2-D4"),
+            (1, 1, 2, 1248, 1848),  # different from the first scene
+            np.uint16,
+            "TCZYX",
+            ["CMDRP"],
+            (2.23, 0.5416666666666666, 0.5416666666666666),
+        ),
         pytest.param(
             "variable_scene_shape_first_scene_pyramid.czi",
             "A1",

--- a/bioio_czi/tests/test_pylibczirw_reader.py
+++ b/bioio_czi/tests/test_pylibczirw_reader.py
@@ -92,6 +92,16 @@ from .conftest import LOCAL_RESOURCES_DIR
             None,
             (None, 1.0833333333333333, 1.0833333333333333),
         ),
+        (
+            "variable_per_scene_dims.czi",
+            "P2-D4",
+            ("P1-D4", "P2-D4"),
+            (1, 1, 2, 1248, 1848),  # different from the first scene
+            np.uint16,
+            "TCZYX",
+            ["CMDRP"],
+            (2.23, 0.5416666666666666, 0.5416666666666666),
+        ),
         pytest.param(
             "variable_scene_shape_first_scene_pyramid.czi",
             "A1",

--- a/bioio_czi/tests/test_pylibczirw_reader.py
+++ b/bioio_czi/tests/test_pylibczirw_reader.py
@@ -96,7 +96,11 @@ from .conftest import LOCAL_RESOURCES_DIR
             "variable_per_scene_dims.czi",
             "P2-D4",
             ("P1-D4", "P2-D4"),
-            (1, 1, 2, 1248, 1848),  # different from the first scene
+            # The dimensions of the second scene are actually (1, 1, 2, 1248, 1848),
+            # but pylibczirw doesn't make that metadata available and instead assumes
+            # all scenes have the same shape.
+            # This is a known defect of pylibczirw mode.
+            (2, 1, 2, 1248, 1848),
             np.uint16,
             "TCZYX",
             ["CMDRP"],

--- a/bioio_czi/tests/test_standard_metadata.py
+++ b/bioio_czi/tests/test_standard_metadata.py
@@ -173,7 +173,9 @@ def test_standard_metadata(
             "variable_per_scene_dims.czi",
             1,
             {
-                "Image Size T": 1,
+                # This should be 1, but pylibczirw assumes all scenes have the same
+                # shape, so this is a known defect of pylibczirw mode.
+                "Image Size T": 2,
             },
         ),
     ],

--- a/bioio_czi/tests/test_standard_metadata.py
+++ b/bioio_czi/tests/test_standard_metadata.py
@@ -147,7 +147,7 @@ def test_standard_metadata(
             {
                 "Image Size T": 2,
                 "Timelapse Interval": 59927.0,
-                "Total Time Duration": "60273.0",
+                "Total Time Duration": "59927.0",
             },
         ),
         (
@@ -157,7 +157,7 @@ def test_standard_metadata(
             {
                 "Image Size T": 1,
                 "Timelapse Interval": None,
-                "Total Time Duration": "343.0",
+                "Total Time Duration": None,
             },
         ),
         (

--- a/bioio_czi/tests/test_standard_metadata.py
+++ b/bioio_czi/tests/test_standard_metadata.py
@@ -10,6 +10,8 @@ from .conftest import LOCAL_RESOURCES_DIR
 # Test each each of the following files in both aicspylibczi and pylibczirw modes.
 #   variable_per_scene_dims.czi
 #   OverViewScan.czi
+# S=2_4x2_T=2=Z=3_CH=2.czi is only tested in aicspylibczi mode since it is used mainly
+# for testing duration and interval, which aren't available in pylibczirw mode.
 @pytest.mark.parametrize(
     "use_aicspylibczi, filename, expected",
     [
@@ -125,6 +127,73 @@ def test_standard_metadata(
     metadata = reader.standard_metadata.to_dict()
 
     # Compare each key's values.
+    for key, expected_value in expected.items():
+        error_message = f"{key}: Expected: {expected_value}, Actual: {metadata[key]}"
+        if isinstance(expected_value, float):
+            assert metadata[key] == pytest.approx(expected_value), error_message
+        else:
+            assert metadata[key] == expected_value, error_message
+
+
+# These test cases are specifically to check that standard_metadata reports metadata
+# of the user-selected scene.
+@pytest.mark.parametrize(
+    "use_aicspylibczi, filename, scene, expected",
+    [
+        (
+            True,
+            "variable_per_scene_dims.czi",
+            0,
+            {
+                "Image Size T": 2,
+                "Timelapse Interval": 59927.0,
+                "Total Time Duration": "60273.0",
+            },
+        ),
+        (
+            True,
+            "variable_per_scene_dims.czi",
+            1,
+            {
+                "Image Size T": 1,
+                "Timelapse Interval": None,
+                "Total Time Duration": "343.0",
+            },
+        ),
+        (
+            False,
+            "variable_per_scene_dims.czi",
+            0,
+            {
+                "Image Size T": 2,
+            },
+        ),
+        (
+            False,
+            "variable_per_scene_dims.czi",
+            1,
+            {
+                "Image Size T": 1,
+            },
+        ),
+    ],
+)
+def test_standard_metadata_with_set_scene(
+    use_aicspylibczi: bool, filename: str, scene: int, expected: dict[str, Any]
+) -> None:
+    # Arrange
+    uri = LOCAL_RESOURCES_DIR / filename
+    reader = Reader(uri, use_aicspylibczi=use_aicspylibczi)
+
+    # Act
+    reader.set_scene(scene)
+    metadata = reader.standard_metadata.to_dict()
+
+    # Sanity check
+    assert reader.current_scene_index == scene
+
+    # Assert
+    # Compare only values mentioned in "expected"
     for key, expected_value in expected.items():
         error_message = f"{key}: Expected: {expected_value}, Actual: {metadata[key]}"
         if isinstance(expected_value, float):


### PR DESCRIPTION
# Issue
Some CZI files have different metadata (e.g., dimension, time interval) per scene. I introduced a bug when adding pylibczirw mode that made a simple `file.set_scene(1); print(file.dims)` stop working.

Unfortunately, [pylibczirw explictly assumes that](https://github.com/ZEISS/pylibczirw/blob/main/API.md#reading-dimension-information) the "plane dimensions are constant across scenes," so I can only really fix aicspylibczi mode.

# Changes
* The primary part of the bugfix [bioio_czi/reader.py](https://github.com/bioio-devs/bioio-czi/compare/dev...standard-metadata-by-scene-2?expand=1#diff-09ddfedcf6e83753504fa94a271d0adf2243b6e0cc28a0f9604d65e3d2051b40): the top level reader's `set_scene` method needs to call the implementation's `set_scene` method.
* I updated the implementation of time interval and time duration to be scene aware.
* Update the README to highlight the defect in pylibczirw mode.
* In adding new test cases, I also found that pylibczirw mode produces different scene names for files with "Shape" metadata in the scenes. I added some logic in the pylibczirw reader to support this.

# Known defects
This PR retains some non-scene-aware logic in the `total_time_duration` function of the aicspylibczi reader. 
The specific problematic code is below. I've left this in for now because my PR #48 removes it in a clean way. If that PR is rejected, I will submit another patch to correct it. I haven't noticed test data yet that exercises this issue.

```python
# Get the number of time points (SizeT)
size_t_element = czi.meta.find(".//SizeT")  # Should just look at one scene!
if size_t_element is None or not size_t_element.text:
    return None

last_timepoint = int(size_t_element.text) - 1
```

# Testing
The new unit tests fail without the fixes here.