### PR TITLE
Duration measures to last acquisition

### DIFF
--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -27,7 +27,7 @@ from .. import metadata as metadata_utils
 from ..bounding_box import size
 from ..channels import get_channel_names
 from ..pixel_sizes import get_physical_pixel_sizes
-from .subblock_metadata import time_between_subblocks
+from .subblock_metadata import elapsed_time_all_subblocks, time_between_subblocks
 
 ###############################################################################
 
@@ -997,7 +997,7 @@ class Reader(BaseReader):
     def total_time_duration(self) -> Optional[str]:
         """
         Extracts the total duration of the timelapse in milliseconds.
-        This is the time between the first acquisition and the first acquisition of the
+        This is the time between the first acquisition and the last acquisition of the
         last timepoint.
 
         Returns
@@ -1010,20 +1010,7 @@ class Reader(BaseReader):
         try:
             with self._fs.open(self._path) as open_resource:
                 czi = CziFile(open_resource.f)
-
-                # Get the number of time points (SizeT)
-                size_t_element = czi.meta.find(".//SizeT")
-                if size_t_element is None or not size_t_element.text:
-                    return None
-
-                last_timepoint = int(size_t_element.text) - 1
-
-                duration = time_between_subblocks(
-                    czi,
-                    self.current_scene_index,
-                    start_subblock_index=0,
-                    end_subblock_index=last_timepoint,
-                )
+                duration = elapsed_time_all_subblocks(czi, self.current_scene_index)
                 return str(duration) if duration is not None else None
 
         except Exception as exc:

--- a/bioio_czi/aicspylibczi_reader/subblock_metadata.py
+++ b/bioio_czi/aicspylibczi_reader/subblock_metadata.py
@@ -50,6 +50,13 @@ def _acquisition_time(
     return _extract_acquisition_time_from_subblock_metadata(metablock_of_first_subblock)
 
 
+def _difference_in_ms(start_time: np.datetime64, end_time: np.datetime64) -> float:
+    delta = end_time - start_time
+    # Difference in milliseconds is delta divided by 1 millisecond
+    # Explicit conversion to float is required, lest we get a numpy float64
+    return float(delta / np.timedelta64(1, "ms"))
+
+
 def time_between_subblocks(
     czi: CziFile, current_scene: int, start_subblock_index: int, end_subblock_index: int
 ) -> Optional[float]:
@@ -58,7 +65,50 @@ def time_between_subblocks(
     end_time = _acquisition_time(czi, current_scene, end_subblock_index)
     if start_time is None or end_time is None:
         return None
-    delta = end_time - start_time
-    # Difference in milliseconds is delta divided by 1 millisecond
-    # Explicit conversion to float is required, lest we get a numpy float64
-    return float(delta / np.timedelta64(1, "ms"))
+    return _difference_in_ms(start_time, end_time)
+
+
+def elapsed_time_all_subblocks(czi: CziFile, current_scene: int) -> Optional[float]:
+    """
+    Looks at all subblocks in the first scene and calculates the time between the first
+    and last.
+
+    Parameters
+    ----------
+    czi: CziFile
+        The CziFile object to extract metadata from.
+    current_scene: int
+        Get the elapsed time from subblocks of just this scene.
+
+    Returns
+    -------
+    Optional[float]
+        The elapsed time in milliseconds between the first and last subblocks with
+        acquisition time metadata, or None if there are fewer than 2 parseable
+        subblocks. This may be greater than the number of timepoints times the interval
+        between timepoints. This may be nonzero even if there is only one timepoint.
+
+    Example
+    -------
+    Consider an image with acquisitions at the following times.
+        T=0 C=0: 2020-01-01 00:01:00.0000000
+        T=0 C=1: 2020-01-01 00:01:00.1234567
+        T=1 C=0: 2020-01-01 00:02:00.0000000
+        T=1 C=1: 2020-01-01 00:02:00.1234567
+    The return value would be 60123.4567 (1 minute and 0.1234567 seconds).
+    """
+    all_subblocks: list[tuple[dict, str]] = czi.read_subblock_metadata(S=current_scene)
+    all_acquisition_times = [
+        _extract_acquisition_time_from_subblock_metadata(metadata)
+        for _, metadata in all_subblocks
+    ]
+    # NaT is numpy's representation of "Not a Time", which is used when parsing fails.
+    filtered_acquisition_times = [
+        t
+        for t in all_acquisition_times
+        if t is not None and t is not np.datetime64("NaT")
+    ]
+    sorted_acquisition_times = np.sort(filtered_acquisition_times)
+    if len(sorted_acquisition_times) < 2:
+        return None
+    return _difference_in_ms(sorted_acquisition_times[0], sorted_acquisition_times[-1])

--- a/bioio_czi/tests/test_standard_metadata.py
+++ b/bioio_czi/tests/test_standard_metadata.py
@@ -37,7 +37,10 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Row": "4",
                 "Timelapse": True,
                 "Timelapse Interval": 59927.0,
-                "Total Time Duration": "59927.0",
+                # Though this file has just 2 timepoints, duration is slightly longer
+                # than timelapse interval because it measures to the last acquisition of
+                # the last timepoint.
+                "Total Time Duration": "60273.0",
             },
         ),
         (
@@ -62,7 +65,9 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Row": None,
                 "Timelapse": False,
                 "Timelapse Interval": None,
-                "Total Time Duration": None,
+                # There's only one timepoint, but the 120 tiles were captured over the
+                # course of about 3 minutes.
+                "Total Time Duration": "187724.7372",
             },
         ),
         (
@@ -87,7 +92,7 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Row": None,
                 "Timelapse": True,
                 "Timelapse Interval": 19160.1933,
-                "Total Time Duration": "19160.1933",
+                "Total Time Duration": "28147.034",
             },
         ),
         (
@@ -172,7 +177,7 @@ def test_standard_metadata(
             {
                 "Image Size T": 2,
                 "Timelapse Interval": 59927.0,
-                "Total Time Duration": "59927.0",
+                "Total Time Duration": "60273.0",
             },
         ),
         (
@@ -182,7 +187,7 @@ def test_standard_metadata(
             {
                 "Image Size T": 1,
                 "Timelapse Interval": None,
-                "Total Time Duration": None,
+                "Total Time Duration": "343.0",
             },
         ),
         (


### PR DESCRIPTION
# Purpose
This PR is perhaps somewhat controversial: it makes timelapse duration measure until the last acquisition of the last timepoint. Generally, an acquisition is just a single XY region, so files with multiple channels or multiple Z slices will have multiple acquisitions per timepoint. As a consequence of this definition of duration, files with a single timepoint but multiple acquisitions have a nonzero duration, and the duration is generally slightly longer than `TimeIncrement * SizeT`.

See [this issue](https://github.com/bioio-devs/bioio/issues/122) for more discussion.

We should not release these changes unless we update the bioio documentation to clarify the meaning of duration.

# Testing
Updated test expectations based on new duration definition. I got the expected values by manually inspecting the files' metadata.

# Notes
If this PR is rejected I will submit another patch that corrects the following non-scene-aware logic that this PR would eliminate.
```python
# Get the number of time points (SizeT)
size_t_element = czi.meta.find(".//SizeT")  # Should just look at one scene!
if size_t_element is None or not size_t_element.text:
    return None

last_timepoint = int(size_t_element.text) - 1
```