### PR TITLE
Duration measures to first acquisition of last frame

### DIFF
--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -984,8 +984,8 @@ class Reader(BaseReader):
                 return time_between_subblocks(
                     czi,
                     self.current_scene_index,
-                    start_subblock_index=0,
-                    end_subblock_index=1,
+                    start_frame=0,
+                    end_frame=1,
                 )
 
         except Exception as exc:
@@ -1007,22 +1007,24 @@ class Reader(BaseReader):
             string to satisfy the StandardMetadata contract.
             Returns None if extraction fails.
         """
+        timepoints = (
+            self.dims[DimensionNames.Time][0]
+            if DimensionNames.Time in self.dims.order
+            else None
+        )
+        if timepoints is None or timepoints < 2:
+            return None
+
         try:
             with self._fs.open(self._path) as open_resource:
                 czi = CziFile(open_resource.f)
-
-                # Get the number of time points (SizeT)
-                size_t_element = czi.meta.find(".//SizeT")
-                if size_t_element is None or not size_t_element.text:
-                    return None
-
-                last_timepoint = int(size_t_element.text) - 1
-
                 duration = time_between_subblocks(
                     czi,
                     self.current_scene_index,
-                    start_subblock_index=0,
-                    end_subblock_index=last_timepoint,
+                    start_frame=0,
+                    # Index of the last timepoint is one less than the number of
+                    # timepoints
+                    end_frame=timepoints - 1,
                 )
                 return str(duration) if duration is not None else None
 


### PR DESCRIPTION
# Purpose
The opposite of #48. This PR addresses some edge cases with how `timelapse_interval` and `total_time_duration` are computed.

Generally, an acquisition is just a single XY region, so files with multiple channels or multiple Z slices will have multiple acquisitions per timepoint. This PR explicitly makes us measure to the first acquisition of a timepoint.

# Changes
* The previous code relied on a convention that, within one timepoint of one scene, Z=0, C=0, R=0, I=0, H=0, V=0 is acquired first. This is not guaranteed by the CZI spec. The new code always picks the first acquisition of the timepoint.
* The previous code assumed that a CZI's global `<SizeT>` metadata correctly describes the time dimension of every scene in the file, which is not necessarily true. 

# Testing
The existing unit tests are unchanged because I don't actually have any CZI files that exercise these edge cases. For instance, we do have a two-scene CZI with different T dimensions per scene, but one scene only has one timepoint, so there's no duration/interval to compute there.