### PR TITLE
bugfix/ome-metadata-size-mismatch

### DIFF
--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -308,10 +308,43 @@ class Reader(BaseReader):
             This likely isn't a complete transformation but is guarenteed to
             be a valid transformation.
         """
-        return metadata.transform_metadata_with_xslt(
+        ome = metadata.transform_metadata_with_xslt(
             self._implementation.metadata,
             Path(__file__).parent / "czi-to-ome-xslt/xslt/czi-to-ome.xsl",
         )
+
+        # NOTE:
+        # The OME metadata generated via XSLT reflects the raw CZI XML, which may
+        # describe the original acquisition frame dimensions. However, the actual
+        # pixel data exposed by this reader is derived from pylibCZIrw bounding boxes
+        # (e.g., scene-specific ROI, stitching, and no-pyramid extents), which can
+        # differ from the XML-reported sizes.
+        #
+        # This can lead to mismatches between `reader.shape` and
+        # `ome_metadata.images[0].pixels.{size_x, size_y}`, particularly for
+        # mosaics or scenes with adjusted bounding regions.
+        #
+        # To ensure consistency and correctness for downstream consumers, we
+        # normalize the OME Pixel sizes to match the dimensions of the data
+        # actually returned by the reader.
+        if not ome.images:
+            return ome
+
+        pixels = ome.images[0].pixels
+        dim_to_size = dict(zip(self.dims.order, self.shape))
+
+        if "X" in dim_to_size:
+            pixels.size_x = dim_to_size["X"]
+        if "Y" in dim_to_size:
+            pixels.size_y = dim_to_size["Y"]
+        if "Z" in dim_to_size:
+            pixels.size_z = dim_to_size["Z"]
+        if "C" in dim_to_size:
+            pixels.size_c = dim_to_size["C"]
+        if "T" in dim_to_size:
+            pixels.size_t = dim_to_size["T"]
+
+        return ome
 
     @property
     def physical_pixel_sizes(self) -> PhysicalPixelSizes:

--- a/bioio_czi/tests/resources/ome_bounding_box_discrepant.czi
+++ b/bioio_czi/tests/resources/ome_bounding_box_discrepant.czi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5235790a9c7a029d64ba41b78db7c6b974d42ae1adfc33a8a4399b571f162ad0
+size 173483488

--- a/bioio_czi/tests/test_pylibczirw_reader.py
+++ b/bioio_czi/tests/test_pylibczirw_reader.py
@@ -310,3 +310,23 @@ def test_scene_stack_consistency() -> None:
     stack_xr_da = reader.get_xarray_dask_stack()
     assert stack_xr_da.shape == expected.shape
     np.testing.assert_array_equal(stack_xr_da.data.compute(), expected)
+
+
+def test_ome_metadata_matches_exposed_shape_for_bounding_box_discrepant_czi() -> None:
+    uri = LOCAL_RESOURCES_DIR / "ome_bounding_box_discrepant.czi"
+
+    reader = Reader(uri)
+
+    # Sanity check the exposed data view that triggered the bug report.
+    assert reader.dims.order == "CZYX"
+    assert reader.shape == (3, 13, 2101, 2101)
+
+    pixels = reader.ome_metadata.images[0].pixels
+
+    # OME metadata should describe the same image shape exposed by the reader.
+    dim_to_size = dict(zip(reader.dims.order, reader.shape))
+
+    assert pixels.size_c == dim_to_size["C"]
+    assert pixels.size_z == dim_to_size["Z"]
+    assert pixels.size_y == dim_to_size["Y"]
+    assert pixels.size_x == dim_to_size["X"]


### PR DESCRIPTION
## Description 

The purpose of this PR is to resolve #88. The reader produces inconsistent metadata because it derives image dimensions from two different sources: the actual pixel data shape is computed using pylibCZIrw scene bounding boxes (including stitching and no-pyramid ROI adjustments), while the OME metadata is generated independently by applying an XSLT transform to the raw CZI XML. As a result, the Pixels.SizeX and SizeY values in ome_metadata can reflect the original acquisition frame (e.g., 1920×1080) rather than the true dimensions of the data returned by the reader (e.g., 2101×2101), leading to a mismatch between metadata and image shape that can cause downstream processing errors.