### PR TITLE
bugfix/reading-bgr-files-with-non-xy-dims

### DIFF
--- a/bioio_czi/pylibczirw_reader/reader.py
+++ b/bioio_czi/pylibczirw_reader/reader.py
@@ -336,20 +336,22 @@ class Reader(BaseReader):
             len(coords[d]) if d in coords else size(self._total_bounding_box, d)
             for d in ordered_dims
         )
-        # E.g., shape_without_yx = (30, 2, 20)
-        shape_without_yx = shape[:-2]
-
-        chunk_shape = shape[-2:]
-        if "Bgr" in self._pixel_types[0]:
-            # If the image is BGR, each chunk has shape (X, Y, 3)
-            chunk_shape += (3,)
-            ordered_dims.append(DimensionNames.Samples)
-
-        # 5. Create delayed chunks
         # The Y and X shape of lazy_arrays are both 1 because we are making each YX
         # slice a single chunk.
         # E.g., lazy_arrays.shape = (30, 2, 20, 1, 1)
-        lazy_arrays: np.ndarray = np.ndarray(shape_without_yx + (1, 1), dtype=object)
+        shape_for_lazyarrays = shape[:-2] + (1, 1)
+
+        chunk_shape = shape[-2:]
+        if "Bgr" in self._pixel_types[0]:
+            # If the image is BGR, each chunk has shape (X, Y, 3)...
+            chunk_shape += (3,)
+            ordered_dims.append(DimensionNames.Samples)
+            # ...and we also need to reflect this in the shape of the lazy_arrays
+            # All the Y, X *and* S points for a slice are in a single chunk
+            shape_for_lazyarrays += (1,)
+
+        # 5. Create delayed chunks
+        lazy_arrays: np.ndarray = np.ndarray(shape_for_lazyarrays, dtype=object)
         for np_index, _ in np.ndenumerate(lazy_arrays):
             lazy_arrays[np_index] = da.from_delayed(
                 delayed(self._array_builder(non_yx_dims))(np_index),

--- a/bioio_czi/tests/resources/RGB-8bit-with-non-xy-dims.czi
+++ b/bioio_czi/tests/resources/RGB-8bit-with-non-xy-dims.czi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53f7448aef78ce58bf29d34b2e364df7fdaef8ba034c3624af3a38f68dda2293
+size 1731744

--- a/bioio_czi/tests/test_pylibczirw_reader.py
+++ b/bioio_czi/tests/test_pylibczirw_reader.py
@@ -93,6 +93,16 @@ from .conftest import LOCAL_RESOURCES_DIR
             (None, 1.0833333333333333, 1.0833333333333333),
         ),
         (
+            "RGB-8bit-with-non-xy-dims.czi",
+            "Image:0",
+            ("Image:0",),
+            (1, 624, 924, 3),
+            np.uint8,
+            "ZYXS",
+            None,
+            (0.0, 1.0833333333333302, 1.0833333333333302),
+        ),
+        (
             "variable_per_scene_dims.czi",
             "P2-D4",
             ("P1-D4", "P2-D4"),


### PR DESCRIPTION
### Description of Changes

BGR images effectively have an extra dimension to handle the fact that each pixel has three bytes, one per colour (this is given the name `S` when using pylibczirw). The `pylibczirw` code was attempting to take this into account by appending a 3 to the end of the `chunk_shape`, but it wasn't doing the same for the shape information passed into the lazy arrays construction. It turns out that this works fine when there are no dimensions in the file other than those included in the `chunk_shape`, but if there is e.g. a Z or C dimension, the `DataArray` `_infer_coords` function errors out complaining that there are "different number of dimensions on data and dims".

Fixing this was simple enough: just appending a 1 to the end of the shape we pass when constructing the lazy arrays, mirroring for S what we do for Y and X. I have added a test using a new file generated by manipulating the existing RGB test file with pylibczirw, as well as testing with one of my own failing czi files.
