### PR TITLE
bugfix: use plate-level scene index for row/column lookup in split CZI files

### DIFF
--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -895,6 +895,21 @@ class Reader(BaseReader):
         return self._construct_mosaic_xarray(self.data)
 
     @property
+    def czi_scene_index(self) -> int:
+        """
+        Returns the plate-level CZI scene index for the current scene.
+
+        For split CZI files (one plate position per file), this differs from
+        current_scene_index (which is always 0) because the embedded XML metadata
+        still uses the original plate-wide scene indices.
+        """
+        with self._fs.open(self._path) as open_resource:
+            czi = CziFile(open_resource.f)
+            return Reader._adjust_scene_index(
+                czi.get_dims_shape(), self.current_scene_index, czi.shape_is_consistent
+            )
+
+    @property
     def physical_pixel_sizes(self) -> types.PhysicalPixelSizes:
         """
         Returns

--- a/bioio_czi/pylibczirw_reader/reader.py
+++ b/bioio_czi/pylibczirw_reader/reader.py
@@ -195,6 +195,17 @@ class Reader(BaseReader):
 
         return coords
 
+    @property
+    def czi_scene_index(self) -> int:
+        """
+        Returns the plate-level CZI scene index for the current scene.
+
+        For split CZI files (one plate position per file), this differs from
+        current_scene_index (which is always 0) because the embedded XML metadata
+        still uses the original plate-wide scene indices.
+        """
+        return self._get_czi_scene_index()
+
     def _get_czi_scene_index(self, scene_index: Optional[int] = None) -> int:
         """
         Map a BioIO scene index (0..N-1) to the underlying CZI scene index.

--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -482,11 +482,10 @@ class Reader(BaseReader):
         # 2. Most of the remaining implementation is identical across pylibczirw and
         # aicspylibczi modes, so it is shared here. The self-contained standard_metadata
         # module holds the implementation for extracting these from the metadata.
-        metadata.column = standard_metadata.column(
-            self.metadata, self.current_scene_index
-        )
+        czi_scene_index = self._implementation.czi_scene_index
+        metadata.column = standard_metadata.column(self.metadata, czi_scene_index)
         metadata.position_index = standard_metadata.position_index(self.current_scene)
-        metadata.row = standard_metadata.row(self.metadata, self.current_scene_index)
+        metadata.row = standard_metadata.row(self.metadata, czi_scene_index)
 
         # 3. Finally, total_time_duration is mode-specific, as only aicspylibczi mode
         # has access to the necessary subblock metadata.


### PR DESCRIPTION
## Summary

- Split CZI plate files embed the full plate XML metadata (all scenes with well coordinates) but store pixel data for only one plate position. The `S` dimension range in `dims_shape` encodes the true plate-level scene index (e.g. `S:(10,11)` → index 10).
- `_row_or_column` was using `current_scene_index` (always `0` for a single-scene file), so every split file resolved to scene 0's well coordinates — Row and Column were identical for all plate positions.
- Adds `czi_scene_index` property to both inner readers (using the existing `_adjust_scene_index` in `aicspylibczi_reader` and `_get_czi_scene_index` in `pylibczirw_reader`) and uses it in the outer reader's `standard_metadata` for Row/Column lookups.

Resolves #94

## Test plan

- [x] Confirm `standard_metadata.row` and `standard_metadata.column` return distinct, correct well coordinates for split CZI files from different plate positions
- [x] All existing `test_standard_metadata` tests pass (9/9)


🤖 Generated with [Claude Code](https://claude.com/claude-code)