### PR TITLE
Add Airyscan raw-data example scripts

### DIFF
--- a/examples/airyscan_bioio_aicspylibczi.py
+++ b/examples/airyscan_bioio_aicspylibczi.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Read Airyscan raw detector planes via bioio-czi in aicspylibczi mode.
+
+Related: https://github.com/bioio-devs/bioio-czi/issues/72
+
+Note: BioImage.xarray_dask_data currently drops the H dimension (32 detectors
+show up as T=1). Use bioio_czi.Reader directly for Airyscan raw access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from bioio import BioImage
+from bioio_czi import Reader
+
+from airyscan_plot import plot_airyscan_planes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Read Airyscan detectors with bioio-czi (aicspylibczi mode)."
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to Airyscan CZI",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Output PNG path (default: <input_stem>_airyscan_bioio.png)",
+    )
+    args = parser.parse_args()
+    path = args.path.expanduser().resolve()
+    output = (
+        args.output.expanduser().resolve()
+        if args.output is not None
+        else path.with_name(f"{path.stem}_airyscan_bioio.png")
+    )
+
+    print(f"Reading: {path}")
+
+    reader = Reader(str(path), use_aicspylibczi=True)
+    da = reader.xarray_dask_data
+
+    print(f"Reader dims order: {reader.dims.order}")
+    print(f"Reader shape:      {reader.shape}")
+    print(f"xarray dims:       {da.dims}")
+    print(f"xarray shape:      {da.shape}")
+    print(f"Channel names:       {list(da.coords['C'].values)}")
+
+    img = BioImage(str(path), reader=Reader, use_aicspylibczi=True)
+    bioio_da = img.xarray_dask_data
+    print()
+    print("BioImage.xarray_dask_data (H is collapsed — issue #72):")
+    print(f"  dims:  {bioio_da.dims}")
+    print(f"  shape: {bioio_da.shape}")
+
+    detector_name = str(da.coords["C"].values[0])
+    sum_name = str(da.coords["C"].values[1])
+
+    # 32 Airyscan detector images for acquisition channel 0 (e.g. AF568-T2)
+    detectors = da.isel(C=0, T=0, Z=0).compute().values
+    print()
+    print(f"Detectors (C=0, T=0, Z=0): shape={detectors.shape}, dtype={detectors.dtype}")
+    print(
+        f"  per-detector max: min={detectors.max(axis=(1, 2)).min():.0f}, "
+        f"max={detectors.max(axis=(1, 2)).max():.0f}"
+    )
+
+    # Airyscan sum channel (e.g. AF568#-T2): only H=0 has data
+    sum_channel = da.isel(C=1, T=0, Z=0, H=0).compute().values
+    print()
+    print(
+        f"Sum channel (C=1, T=0, Z=0, H=0): shape={sum_channel.shape}, "
+        f"max={float(sum_channel.max()):.0f}"
+    )
+
+    assert da.sizes["H"] == 32, f"expected 32 detectors on H, got {da.sizes['H']}"
+    assert detectors.shape == (32, da.sizes["Y"], da.sizes["X"])
+    assert sum_channel.shape == (da.sizes["Y"], da.sizes["X"])
+    assert float(sum_channel.max()) > 0
+
+    plot_airyscan_planes(
+        detectors,
+        sum_channel,
+        detector_label=detector_name,
+        sum_label=f"{sum_name} (sum, H=0)",
+        output=output,
+    )
+    print()
+    print(f"Wrote plot: {output}")
+    print("OK: extracted 32 detector planes and sum channel via Reader.xarray_dask_data")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/airyscan_plot.py
+++ b/examples/airyscan_plot.py
@@ -1,0 +1,60 @@
+"""Plot Airyscan detector planes and sum channel."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_airyscan_planes(
+    detectors: np.ndarray,
+    sum_channel: np.ndarray,
+    *,
+    detector_label: str,
+    sum_label: str,
+    output: Path,
+) -> None:
+    """
+    Plot all H detector slices in a grid plus the sum channel below.
+
+    Parameters
+    ----------
+    detectors
+        Array with shape (H, Y, X).
+    sum_channel
+        Array with shape (Y, X).
+    detector_label
+        Title prefix for detector panels (e.g. channel name).
+    sum_label
+        Title for the sum channel panel.
+    output
+        Path to write the PNG figure.
+    """
+    h_count, _, _ = detectors.shape
+    cols = 8
+    detector_rows = int(np.ceil(h_count / cols))
+
+    fig = plt.figure(figsize=(2.2 * cols, 2.2 * detector_rows + 3), layout="constrained")
+    grid = fig.add_gridspec(detector_rows + 1, cols, height_ratios=[1] * detector_rows + [1.4])
+
+    vmin, vmax = np.percentile(detectors, (1, 99.5))
+
+    for h in range(h_count):
+        row, col = divmod(h, cols)
+        ax = fig.add_subplot(grid[row, col])
+        ax.imshow(detectors[h], cmap="gray", vmin=vmin, vmax=vmax, interpolation="nearest")
+        ax.set_title(f"H={h}", fontsize=8)
+        ax.axis("off")
+
+    sum_ax = fig.add_subplot(grid[detector_rows, :])
+    sum_vmin, sum_vmax = np.percentile(sum_channel, (1, 99.5))
+    sum_ax.imshow(sum_channel, cmap="gray", vmin=sum_vmin, vmax=sum_vmax, interpolation="nearest")
+    sum_ax.set_title(sum_label, fontsize=10)
+    sum_ax.axis("off")
+
+    fig.suptitle(f"{detector_label}: {h_count} detector planes + sum", fontsize=12)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, dpi=150, bbox_inches="tight")
+    plt.close(fig)

--- a/examples/airyscan_pylibczirw.py
+++ b/examples/airyscan_pylibczirw.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Read Airyscan raw detector planes via pylibCZIrw (default bioio backend).
+
+Airyscan stores 32 individual detectors on the H dimension, not T.
+Related: https://github.com/bioio-devs/bioio-czi/issues/72
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+from pylibCZIrw import czi as pyczi
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from airyscan_plot import plot_airyscan_planes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Read Airyscan detectors with pylibCZIrw (H dimension)."
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to Airyscan CZI",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Output PNG path (default: <input_stem>_airyscan_pylibczirw.png)",
+    )
+    args = parser.parse_args()
+    path = args.path.expanduser().resolve()
+    output = (
+        args.output.expanduser().resolve()
+        if args.output is not None
+        else path.with_name(f"{path.stem}_airyscan_pylibczirw.png")
+    )
+
+    print(f"Reading: {path}")
+
+    with pyczi.open_czi(str(path)) as cz:
+        bbox = cz.total_bounding_box
+        print(f"total_bounding_box: {bbox}")
+
+        h_count = bbox["H"][1] - bbox["H"][0]
+        c_count = bbox["C"][1] - bbox["C"][0]
+        print(f"H planes (detectors): {h_count}")
+        print(f"C channels:           {c_count}")
+
+        planes = [
+            np.asarray(cz.read(plane={"H": h, "C": 0, "Z": 0})).squeeze()
+            for h in range(h_count)
+        ]
+        detectors = np.stack(planes, axis=0)
+
+        sum_img = np.asarray(cz.read(plane={"H": 0, "C": 1, "Z": 0})).squeeze()
+
+        print()
+        print(
+            f"Detectors (C=0, Z=0, H=0..{h_count - 1}): "
+            f"shape={detectors.shape}, dtype={detectors.dtype}"
+        )
+        print(
+            f"  per-detector max: min={detectors.max(axis=(1, 2)).min()}, "
+            f"max={detectors.max(axis=(1, 2)).max()}"
+        )
+
+        print()
+        print(f"Sum channel (C=1, Z=0, H=0): shape={sum_img.shape}, max={sum_img.max()}")
+
+        nonzero_sum_h = [
+            h
+            for h in range(h_count)
+            if np.asarray(cz.read(plane={"H": h, "C": 1, "Z": 0})).max() > 0
+        ]
+        print(f"Sum channel non-zero at H indices: {nonzero_sum_h}")
+
+    assert detectors.shape[0] == 32
+    assert sum_img.max() > 0
+    assert nonzero_sum_h == [0]
+
+    plot_airyscan_planes(
+        detectors,
+        sum_img,
+        detector_label="C=0 (detectors)",
+        sum_label="C=1 (sum, H=0)",
+        output=output,
+    )
+    print()
+    print(f"Wrote plot: {output}")
+    print("OK: extracted 32 detector planes and sum channel via pylibCZIrw")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add example scripts for reading Airyscan raw detector planes from CZI files (32 planes on dimension `H`, not `T`).
- Demonstrate two working approaches: `bioio_czi.Reader` with `use_aicspylibczi=True` and direct `pylibCZIrw` access.
- Include a shared plotting helper that writes all 32 `H` slices plus the sum channel to a PNG.

Related to #72.

## Test plan
- [x] `python examples/airyscan_pylibczirw.py /path/to/airyscan.czi -o /tmp/out.png`
- [x] `python examples/airyscan_bioio_aicspylibczi.py /path/to/airyscan.czi -o /tmp/out.png`
- [x] Verified on the Zenodo test file from #72 (`H: (0, 32)`, sum channel non-zero at `H=0` only)


Made with [Cursor](https://cursor.com)