### PR TITLE
bugfix: use plate-level CZI scene index for mosaic bounding box calls in split CZI files

### DIFF
--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -149,6 +149,7 @@ class Reader(BaseReader):
         # Delayed storage
         self._px_sizes: Optional[types.PhysicalPixelSizes] = None
         self._mapped_dims: Optional[str] = None
+        self._czi_scene_index: Optional[int] = None
 
         # Enforce valid image
         if not self._is_supported_image(self._fs, self._path):
@@ -169,6 +170,7 @@ class Reader(BaseReader):
         super()._reset_self()
         self._mapped_dims = None
         self._px_sizes = None
+        self._czi_scene_index = None
 
     @staticmethod
     def _fix_czi_dims(dims: str) -> str:
@@ -830,18 +832,16 @@ class Reader(BaseReader):
         # Get max of mosaic positions from lif
         with self._fs.open(self._path) as open_resource:
             czi = CziFile(open_resource.f)
-            czi_dims_shape = czi.get_dims_shape()
-            czi_scene_index = Reader._adjust_scene_index(
-                czi_dims_shape, self.current_scene_index, czi.shape_is_consistent
-            )
             dims_shape = Reader._dims_shape_to_scene_dims_shape(
-                dims_shape=czi_dims_shape,
+                dims_shape=czi.get_dims_shape(),
                 scene_index=self.current_scene_index,
                 consistent=czi.shape_is_consistent,
             )
 
-            bboxes = czi.get_all_mosaic_tile_bounding_boxes(S=czi_scene_index)
-            mosaic_scene_bbox = czi.get_mosaic_scene_bounding_box(index=czi_scene_index)
+            bboxes = czi.get_all_mosaic_tile_bounding_boxes(S=self.czi_scene_index)
+            mosaic_scene_bbox = czi.get_mosaic_scene_bounding_box(
+                index=self.czi_scene_index
+            )
 
             # Stitch
             stitched = self._stitch_tiles(
@@ -905,11 +905,15 @@ class Reader(BaseReader):
         current_scene_index (which is always 0) because the embedded XML metadata
         still uses the original plate-wide scene indices.
         """
-        with self._fs.open(self._path) as open_resource:
-            czi = CziFile(open_resource.f)
-            return Reader._adjust_scene_index(
-                czi.get_dims_shape(), self.current_scene_index, czi.shape_is_consistent
-            )
+        if self._czi_scene_index is None:
+            with self._fs.open(self._path) as open_resource:
+                czi = CziFile(open_resource.f)
+                self._czi_scene_index = Reader._adjust_scene_index(
+                    czi.get_dims_shape(),
+                    self.current_scene_index,
+                    czi.shape_is_consistent,
+                )
+        return self._czi_scene_index
 
     @property
     def physical_pixel_sizes(self) -> types.PhysicalPixelSizes:
@@ -977,9 +981,6 @@ class Reader(BaseReader):
 
         with self._fs.open(self._path) as open_resource:
             czi = CziFile(open_resource.f)
-            czi_scene_index = Reader._adjust_scene_index(
-                czi.get_dims_shape(), self.current_scene_index, czi.shape_is_consistent
-            )
 
             # Default Channel and Time dimensions to 0 to improve
             # worst case read time for large files **only**
@@ -989,7 +990,7 @@ class Reader(BaseReader):
                     kwargs[dimension_name] = 0
 
             bbox = czi.get_mosaic_tile_bounding_box(
-                M=mosaic_tile_index, S=czi_scene_index, **kwargs
+                M=mosaic_tile_index, S=self.czi_scene_index, **kwargs
             )
             return bbox.y, bbox.x
 
@@ -1023,12 +1024,9 @@ class Reader(BaseReader):
 
         with self._fs.open(self._path) as open_resource:
             czi = CziFile(open_resource.f)
-            czi_scene_index = Reader._adjust_scene_index(
-                czi.get_dims_shape(), self.current_scene_index, czi.shape_is_consistent
-            )
 
             tile_info_to_bboxes = czi.get_all_mosaic_tile_bounding_boxes(
-                S=czi_scene_index, **kwargs
+                S=self.czi_scene_index, **kwargs
             )
 
             # Convert dictionary of tile info mappings to
@@ -1060,7 +1058,7 @@ class Reader(BaseReader):
             czi = CziFile(open_resource.f)
             return acquisition_times(
                 czi=czi,
-                current_scene=self.current_scene_index,
+                current_scene=self.czi_scene_index,
             )
 
     @property
@@ -1117,7 +1115,7 @@ class Reader(BaseReader):
                 czi = CziFile(open_resource.f)
                 duration_ms = time_between_subblocks(
                     czi,
-                    self.current_scene_index,
+                    self.czi_scene_index,
                     start_frame=0,
                     # Index of the last timepoint is one less than the number of
                     # timepoints

--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -830,16 +830,18 @@ class Reader(BaseReader):
         # Get max of mosaic positions from lif
         with self._fs.open(self._path) as open_resource:
             czi = CziFile(open_resource.f)
+            czi_dims_shape = czi.get_dims_shape()
+            czi_scene_index = Reader._adjust_scene_index(
+                czi_dims_shape, self.current_scene_index, czi.shape_is_consistent
+            )
             dims_shape = Reader._dims_shape_to_scene_dims_shape(
-                dims_shape=czi.get_dims_shape(),
+                dims_shape=czi_dims_shape,
                 scene_index=self.current_scene_index,
                 consistent=czi.shape_is_consistent,
             )
 
-            bboxes = czi.get_all_mosaic_tile_bounding_boxes(S=self.current_scene_index)
-            mosaic_scene_bbox = czi.get_mosaic_scene_bounding_box(
-                index=self.current_scene_index
-            )
+            bboxes = czi.get_all_mosaic_tile_bounding_boxes(S=czi_scene_index)
+            mosaic_scene_bbox = czi.get_mosaic_scene_bounding_box(index=czi_scene_index)
 
             # Stitch
             stitched = self._stitch_tiles(
@@ -975,6 +977,9 @@ class Reader(BaseReader):
 
         with self._fs.open(self._path) as open_resource:
             czi = CziFile(open_resource.f)
+            czi_scene_index = Reader._adjust_scene_index(
+                czi.get_dims_shape(), self.current_scene_index, czi.shape_is_consistent
+            )
 
             # Default Channel and Time dimensions to 0 to improve
             # worst case read time for large files **only**
@@ -984,7 +989,7 @@ class Reader(BaseReader):
                     kwargs[dimension_name] = 0
 
             bbox = czi.get_mosaic_tile_bounding_box(
-                M=mosaic_tile_index, S=self.current_scene_index, **kwargs
+                M=mosaic_tile_index, S=czi_scene_index, **kwargs
             )
             return bbox.y, bbox.x
 
@@ -1018,9 +1023,12 @@ class Reader(BaseReader):
 
         with self._fs.open(self._path) as open_resource:
             czi = CziFile(open_resource.f)
+            czi_scene_index = Reader._adjust_scene_index(
+                czi.get_dims_shape(), self.current_scene_index, czi.shape_is_consistent
+            )
 
             tile_info_to_bboxes = czi.get_all_mosaic_tile_bounding_boxes(
-                S=self.current_scene_index, **kwargs
+                S=czi_scene_index, **kwargs
             )
 
             # Convert dictionary of tile info mappings to

--- a/bioio_czi/tests/resources/mosaic_split_plate_scene_index_offset.czi
+++ b/bioio_czi/tests/resources/mosaic_split_plate_scene_index_offset.czi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2f37683485bd38dba658d906a515ffe414b6f1d3970d70de0fc34148343847f
+size 311366816

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -142,6 +142,16 @@ def test_subblocks(filename: str, num_subblocks: int, acquistion_time: str) -> N
             ["CMDRP"],
             (2.23, 0.5416666666666666, 0.5416666666666666),
         ),
+        (
+            "mosaic_split_plate_scene_index_offset.czi",
+            "B7-B7",
+            ("B7-B7",),
+            (1, 50, 1248, 1848),
+            np.uint16,
+            "CMYX",
+            ["Bright ONLY"],
+            (None, 0.5416666666666666, 0.5416666666666666),
+        ),
         pytest.param(
             "variable_scene_shape_first_scene_pyramid.czi",
             "A1",
@@ -721,6 +731,13 @@ def test_czi_reader_mosaic_tile_inspection(
             np.arange(0, 2488.45326089585, 4.5743626119409),
             np.arange(0, 14692.852709554172, 4.5743626119409),
             np.arange(0, 33836.560240526844, 4.5743626119409),
+        ),
+        (
+            "mosaic_split_plate_scene_index_offset.czi",
+            np.arange(0, 1248 * 0.5416666666666666, 0.5416666666666666),
+            np.arange(0, 1848 * 0.5416666666666666, 0.5416666666666666),
+            np.arange(0, 10233 * 0.5416666666666666, 0.5416666666666666),
+            np.arange(0, 10164 * 0.5416666666666666, 0.5416666666666666),
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Closes #99

- Apply `_adjust_scene_index` to all three mosaic bounding box call sites (`_construct_mosaic_xarray`, `get_mosaic_tile_position`, `get_mosaic_tile_positions`) so they pass the CZI-level scene coordinate instead of bioio's 0-based `current_scene_index`.
- Fix call ordering in `_construct_mosaic_xarray` so `_adjust_scene_index` runs before `_dims_shape_to_scene_dims_shape`, which mutates the shared `dims_shape` dict by popping the `S` key — previously this caused the scene range to be absent when `_adjust_scene_index` ran, making it silently return `0`.

## Test plan

- [x] Open a split CZI file whose embedded scene index is non-zero (e.g. `S=5`) with `use_aicspylibczi=True` and confirm `img.dims` and mosaic stitching succeed without `PylibCZI_CDimCoordinatesOverspecifiedException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)