### PR TITLE
Serve hyper-rectangular get_image_data selections via a held-open region read

### DIFF
--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import xml.etree.ElementTree as ET
 from copy import copy
@@ -20,6 +21,7 @@ from bioio_base.dimensions import (
     Dimensions,
 )
 from bioio_base.reader import Reader as BaseReader
+from bioio_base.transforms import reshape_data
 from dask import delayed
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
@@ -39,6 +41,11 @@ log = logging.getLogger(__name__)
 CZI_SAMPLES_DIM_CHAR = "A"
 CZI_BLOCK_DIM_CHAR = "B"
 CZI_SCENE_DIM_CHAR = "S"
+
+# Mapped (public) dimension char <-> CZI-native char. They differ only for the
+# samples axis: CZI uses "A", the reader exposes it as DimensionNames.Samples.
+_CZI_CHAR = {DimensionNames.Samples: CZI_SAMPLES_DIM_CHAR}
+_MAPPED_CHAR = {CZI_SAMPLES_DIM_CHAR: DimensionNames.Samples}
 
 
 ###############################################################################
@@ -581,6 +588,158 @@ class Reader(BaseReader):
                 coords[dim_name] = Reader._generate_coord_array(0, dim_size, scale)
 
         return coords, px_sizes
+
+    def _read_region(
+        self, dimension_order_out: Optional[str] = None, **kwargs: Any
+    ) -> np.ndarray:
+        """
+        Read a hyper-rectangular region of the current scene directly from the
+        file, holding it open for the whole region.
+
+        Like the pylibczirw backend's region read, this opens the CZI once and
+        streams only the requested planes via ``CziFile.read_image`` -- avoiding
+        both the per-plane dask graph construction and the per-plane file reopen
+        that ``get_image_dask_data(...).compute()`` incurs. ``aicspylibczi`` has
+        no XY ROI, so XY sub-regions are cropped from full planes in numpy;
+        memory is still bounded to the requested region.
+
+        Dimensions omitted from ``dimension_order_out`` and not selected via
+        ``kwargs`` are pruned to index 0, matching ``reshape_data`` / the base
+        ``get_image_data`` behavior (used e.g. for mosaic ``M`` tiles).
+        """
+        native_order = self.mapped_dims
+        target_order = (
+            dimension_order_out if dimension_order_out is not None else native_order
+        )
+        frame_axes = {
+            DimensionNames.SpatialY,
+            DimensionNames.SpatialX,
+            DimensionNames.Samples,
+        }
+
+        with self._fs.open(self._path) as open_resource:
+            czi = CziFile(open_resource.f)
+            adjusted_scene = Reader._adjust_scene_index(
+                czi.get_dims_shape(),
+                self.current_scene_index,
+                czi.shape_is_consistent,
+            )
+            dims_shape = Reader._dims_shape_to_scene_dims_shape(
+                czi.get_dims_shape(),
+                self.current_scene_index,
+                czi.shape_is_consistent,
+            )
+            dims_shape.pop(CZI_BLOCK_DIM_CHAR, None)
+            # dims_shape values are (begin, end) per native (mapped) dimension.
+            begin = {d: dims_shape[_CZI_CHAR.get(d, d)][0] for d in native_order}
+            sizes = {
+                d: dims_shape[_CZI_CHAR.get(d, d)][1]
+                - dims_shape[_CZI_CHAR.get(d, d)][0]
+                for d in native_order
+            }
+
+            # Resolve each native dimension to a (start, stop) read window.
+            windows: Dict[str, Tuple[int, int]] = {}
+            for d in native_order:
+                if d in kwargs and isinstance(kwargs[d], slice):
+                    if kwargs[d].step not in (None, 1):
+                        raise ValueError(
+                            "read_region only supports contiguous slices; got step "
+                            f"{kwargs[d].step} for dimension {d!r}."
+                        )
+                    start, stop, _ = kwargs[d].indices(sizes[d])
+                    windows[d] = (start, stop)
+                elif d in kwargs:
+                    idx = int(kwargs[d]) % sizes[d]
+                    windows[d] = (idx, idx + 1)
+                elif d in target_order:
+                    windows[d] = (0, sizes[d])
+                else:
+                    # Pruned dimension (omitted, not selected): index 0.
+                    windows[d] = (0, 1)
+
+            pixel_type = PIXEL_DICT.get(czi.pixel_type)
+            if pixel_type is None:
+                raise TypeError(f"Pixel type: {czi.pixel_type} is not supported.")
+
+            out_shape = tuple(windows[d][1] - windows[d][0] for d in native_order)
+            region = np.empty(out_shape, dtype=pixel_type)
+
+            yx_window = {
+                DimensionNames.SpatialY: windows[DimensionNames.SpatialY],
+                DimensionNames.SpatialX: windows[DimensionNames.SpatialX],
+            }
+            loop_axes = [d for d in native_order if d not in frame_axes]
+            ranges = [range(*windows[d]) for d in loop_axes]
+            region_frame_order = [d for d in native_order if d in frame_axes]
+
+            for combo in itertools.product(*ranges):
+                read_dims = {CZI_SCENE_DIM_CHAR: adjusted_scene}
+                for i, d in enumerate(loop_axes):
+                    read_dims[_CZI_CHAR.get(d, d)] = begin[d] + combo[i]
+
+                data, data_dims = czi.read_image(**read_dims)
+
+                # Build a crop/squeeze index over data_dims, mapping native
+                # (mapped) axes back to CZI chars; YX cropped, others dropped.
+                ops: List[Union[int, slice]] = []
+                plane_order: List[str] = []
+                for char, _ in data_dims:
+                    mapped = _MAPPED_CHAR.get(char, char)
+                    if char in read_dims or char == CZI_BLOCK_DIM_CHAR:
+                        ops.append(0)
+                    elif mapped in yx_window:
+                        ops.append(slice(*yx_window[mapped]))
+                        plane_order.append(mapped)
+                    else:
+                        ops.append(slice(None))
+                        plane_order.append(mapped)
+                plane = data[tuple(ops)]
+
+                # Reorder plane frame axes to the region's frame-axis order.
+                if plane_order != region_frame_order:
+                    plane = np.transpose(
+                        plane, [plane_order.index(d) for d in region_frame_order]
+                    )
+
+                out_idx: List[Any] = [slice(None)] * len(native_order)
+                for i, d in enumerate(loop_axes):
+                    out_idx[native_order.index(d)] = combo[i] - windows[d][0]
+                region[tuple(out_idx)] = plane
+
+        if target_order == native_order:
+            return region
+        return reshape_data(
+            data=region, given_dims=native_order, return_dims=target_order
+        )
+
+    def get_image_data(
+        self, dimension_order_out: Optional[str] = None, **kwargs: Any
+    ) -> np.ndarray:
+        """
+        Read specific dimension image data as a numpy array.
+
+        When the selection is a hyper-rectangle -- every keyword is an ``int``
+        or a contiguous ``slice`` and at least one is a ``slice`` -- this reads
+        only the requested planes directly from a single held-open file via
+        :meth:`_read_region`, avoiding the per-plane dask graph and per-plane
+        file reopen that the base (whole-image) path incurs. All other
+        selections (lists, ranges, strided slices, or no keywords) defer to the
+        base implementation. See the base ``Reader.get_image_data`` for
+        parameter details.
+        """
+        routable = (
+            bool(kwargs)
+            and any(isinstance(v, slice) for v in kwargs.values())
+            and all(
+                isinstance(v, (int, np.integer))
+                or (isinstance(v, slice) and v.step in (None, 1))
+                for v in kwargs.values()
+            )
+        )
+        if routable:
+            return self._read_region(dimension_order_out, **kwargs)
+        return super().get_image_data(dimension_order_out, **kwargs)
 
     def _read_delayed(self) -> xr.DataArray:
         """

--- a/bioio_czi/pylibczirw_reader/reader.py
+++ b/bioio_czi/pylibczirw_reader/reader.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import itertools
 import logging
-from typing import Any, Callable, ContextManager, Dict, Optional, Tuple, Union
+from typing import Any, Callable, ContextManager, Dict, List, Optional, Tuple, Union
 from xml.etree import ElementTree as ET
 
 import dask.array as da
@@ -15,6 +16,7 @@ from bioio_base.dimensions import (
     Dimensions,
 )
 from bioio_base.reader import Reader as BaseReader
+from bioio_base.transforms import reshape_data
 from bioio_base.types import PhysicalPixelSizes
 from dask import delayed
 from fsspec.spec import AbstractFileSystem
@@ -388,6 +390,174 @@ class Reader(BaseReader):
             The fully read data array.
         """
         return self._read_delayed().compute()
+
+    def _scene_dims_and_shape(self) -> Tuple[str, Tuple[int, ...]]:
+        """
+        Native dimension order and shape of the current scene, derived from the
+        bounding boxes alone -- i.e. without building the per-plane dask graph
+        that ``self.dims`` / ``self.shape`` would trigger via ``_read_delayed``.
+
+        Mirrors the dimension/shape bookkeeping in ``_read_delayed`` (including
+        the trailing ``Samples`` axis for BGR images); keep the two in sync.
+        """
+        dim_bounds = dict(self._total_bounding_box)
+        if len(self._scenes_bounding_rectangle) > 0:
+            rect = self._scenes_bounding_rectangle[self._get_czi_scene_index()]
+            dim_bounds[DimensionNames.SpatialX] = (rect.x, rect.x + rect.w)
+            dim_bounds[DimensionNames.SpatialY] = (rect.y, rect.y + rect.h)
+
+        coords = self._get_coords(
+            self.metadata, self._get_czi_scene_index(), dim_bounds
+        )
+        ordered_dims = [
+            d
+            for d in DEFAULT_DIMENSION_ORDER_LIST
+            if d in coords or size(self._total_bounding_box, d) > 1
+        ]
+        assert ordered_dims[-2:] == [
+            DimensionNames.SpatialY,
+            DimensionNames.SpatialX,
+        ]
+        shape = tuple(
+            len(coords[d]) if d in coords else size(self._total_bounding_box, d)
+            for d in ordered_dims
+        )
+        if "Bgr" in self._pixel_types[0]:
+            ordered_dims = ordered_dims + [DimensionNames.Samples]
+            shape = shape + (3,)
+        return "".join(ordered_dims), shape
+
+    def _read_region(
+        self,
+        dimension_order_out: Optional[str] = None,
+        **kwargs: Any,
+    ) -> np.ndarray:
+        """
+        Read a hyper-rectangular region of the current scene directly from the
+        file, holding it open for the whole region. This is the backbone of
+        :meth:`get_image_data` for sliced selections; it is not public API.
+
+        Unlike ``get_image_dask_data(...).compute()`` -- which builds a
+        per-plane dask graph and re-opens the file for every YX slice -- this
+        opens the CZI once and streams only the requested planes, cropping each
+        to the requested XY sub-region via a pylibCZIrw ROI. It never
+        materializes the full image, so partial reads are both faster and
+        memory-bounded.
+
+        Parameters
+        ----------
+        dimension_order_out: Optional[str]
+            Desired dimension order of the result. Default: the image's native
+            order. Dimensions selected by a scalar ``int`` and absent from this
+            order are dropped, matching ``get_image_data``.
+        kwargs: Any
+            Per-dimension selection. Each value is either an ``int`` (a single
+            index) or a contiguous ``slice`` (``step`` must be ``1`` or
+            ``None``). Unspecified dimensions are read in full. ``X``/``Y``
+            selections become the ROI; all other dimensions are iterated
+            plane-by-plane.
+
+        Returns
+        -------
+        np.ndarray
+            The region, in ``dimension_order_out``.
+        """
+        native_order, native_shape = self._scene_dims_and_shape()
+        dim_sizes = dict(zip(native_order, native_shape))
+        frame_axes = {
+            DimensionNames.SpatialY,
+            DimensionNames.SpatialX,
+            DimensionNames.Samples,
+        }
+
+        # Resolve each native dimension to a (start, stop) read window.
+        windows: Dict[str, Tuple[int, int]] = {}
+        for d in native_order:
+            if d not in kwargs:
+                windows[d] = (0, dim_sizes[d])
+            elif isinstance(kwargs[d], slice):
+                if kwargs[d].step not in (None, 1):
+                    raise ValueError(
+                        "read_region only supports contiguous slices; got step "
+                        f"{kwargs[d].step} for dimension {d!r}."
+                    )
+                start, stop, _ = kwargs[d].indices(dim_sizes[d])
+                windows[d] = (start, stop)
+            elif isinstance(kwargs[d], (int, np.integer)):
+                idx = int(kwargs[d]) % dim_sizes[d]
+                windows[d] = (idx, idx + 1)
+            else:
+                raise TypeError(
+                    f"read_region selection for {d!r} must be int or slice, got "
+                    f"{type(kwargs[d]).__name__}."
+                )
+
+        # XY origin: per-scene for scened files, total bounding box otherwise.
+        if len(self._scenes_bounding_rectangle) == 0:
+            scene: Optional[int] = None
+            base_x = self._total_bounding_box[DimensionNames.SpatialX][0]
+            base_y = self._total_bounding_box[DimensionNames.SpatialY][0]
+        else:
+            scene = self._get_czi_scene_index()
+            rect = self._scenes_bounding_rectangle[scene]
+            base_x, base_y = rect.x, rect.y
+
+        x0, x1 = windows[DimensionNames.SpatialX]
+        y0, y1 = windows[DimensionNames.SpatialY]
+        roi = (base_x + x0, base_y + y0, x1 - x0, y1 - y0)
+
+        out_shape = tuple(windows[d][1] - windows[d][0] for d in native_order)
+        region = np.empty(out_shape, dtype=PIXEL_DICT[self._pixel_types[0].lower()])
+        has_samples = DimensionNames.Samples in native_order
+
+        loop_axes = [d for d in native_order if d not in frame_axes]
+        ranges = [range(*windows[d]) for d in loop_axes]
+
+        with open(self._path) as file:
+            for combo in itertools.product(*ranges):
+                plane = {d: combo[i] for i, d in enumerate(loop_axes)}
+                raw = file.read(scene=scene, plane=plane, roi=roi)
+                # raw is (Y, X, 1) grayscale or (Y, X, 3) BGR.
+                result = raw if has_samples else raw[..., 0]
+                out_idx: List[Any] = [slice(None)] * len(native_order)
+                for i, d in enumerate(loop_axes):
+                    out_idx[native_order.index(d)] = combo[i] - windows[d][0]
+                region[tuple(out_idx)] = result
+
+        if dimension_order_out is None or dimension_order_out == native_order:
+            return region
+        return reshape_data(
+            data=region,
+            given_dims=native_order,
+            return_dims=dimension_order_out,
+        )
+
+    def get_image_data(
+        self, dimension_order_out: Optional[str] = None, **kwargs: Any
+    ) -> np.ndarray:
+        """
+        Read specific dimension image data as a numpy array.
+
+        When the selection is a hyper-rectangle -- every keyword is an ``int``
+        or a contiguous ``slice`` and at least one is a ``slice`` -- this reads
+        only the requested bytes directly from the file (holding it open for the
+        whole region) instead of materializing the whole image first. All other
+        selections (lists, ranges, strided slices, or no keywords) defer to the
+        base implementation. See the base ``Reader.get_image_data`` for
+        parameter details.
+        """
+        routable = (
+            bool(kwargs)
+            and any(isinstance(v, slice) for v in kwargs.values())
+            and all(
+                isinstance(v, (int, np.integer))
+                or (isinstance(v, slice) and v.step in (None, 1))
+                for v in kwargs.values()
+            )
+        )
+        if routable:
+            return self._read_region(dimension_order_out, **kwargs)
+        return super().get_image_data(dimension_order_out, **kwargs)
 
     def _get_stitched_dask_mosaic(self) -> xr.DataArray:
         """

--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union
 from xml.etree import ElementTree
 
+import numpy as np
 import xarray as xr
 from bioio_base.dimensions import Dimensions
 from bioio_base.exceptions import UnsupportedFileFormatError
@@ -189,6 +190,19 @@ class Reader(BaseReader):
     @property
     def current_scene_index(self) -> int:
         return self._implementation.current_scene_index
+
+    def get_image_data(
+        self, dimension_order_out: Optional[str] = None, **kwargs: Any
+    ) -> np.ndarray:
+        """
+        Read specific dimension image data as a numpy array.
+
+        Delegates to the active backend. In pylibczirw mode a hyper-rectangular
+        selection (ints / contiguous slices, with at least one slice) is read
+        directly from the file instead of materializing the whole image first;
+        all other selections use the base behavior.
+        """
+        return self._implementation.get_image_data(dimension_order_out, **kwargs)
 
     def _read_delayed(self) -> xr.DataArray:
         """

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -826,3 +826,47 @@ def test_czi_reader_stitch_tiles_clamps_bbox_mismatch() -> None:
 
     # The overlapping region should match the original tile data
     np.testing.assert_array_equal(stitched[:, 0:4, 0:5], tile_data)
+
+
+@pytest.mark.parametrize(
+    "order, selection",
+    [
+        ("TCZYX", {"T": slice(0, 1)}),  # mosaic M omitted -> pruned to tile 0
+        ("TCZYX", {"Z": slice(1, 3)}),
+        ("ZYX", {"T": 0, "C": 1}),
+        ("CYX", {"T": 1, "Z": 2, "Y": slice(10, 60), "X": slice(20, 90)}),
+        ("HTCZMYX", {"M": slice(0, 4), "Z": slice(1, 3)}),  # keep + slice M tiles
+        ("MYX", {"H": 0, "T": 1, "C": 1, "Z": 2}),  # mosaic tile as output axis
+    ],
+)
+def test_get_image_data_slicing_matches_base(order: str, selection: dict) -> None:
+    """
+    In aicspylibczi mode a hyper-rectangular get_image_data selection reads only
+    the requested region directly from a single held-open file, and must equal
+    what the base (whole-image-then-slice) implementation returns.
+    """
+    from bioio_base.reader import Reader as BaseReader
+
+    uri = LOCAL_RESOURCES_DIR / "S=2_4x2_T=2=Z=3_CH=2.czi"
+    reader = Reader(uri, use_aicspylibczi=True)
+    reader.set_scene(0)
+
+    actual = reader.get_image_data(order, **selection)
+    expected = BaseReader.get_image_data(reader._implementation, order, **selection)
+
+    assert actual.shape == expected.shape
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_get_image_data_non_slice_defers_to_base_aics() -> None:
+    """Non-hyper-rectangular selections (e.g. a list) still defer to base."""
+    from bioio_base.reader import Reader as BaseReader
+
+    uri = LOCAL_RESOURCES_DIR / "S=2_4x2_T=2=Z=3_CH=2.czi"
+    reader = Reader(uri, use_aicspylibczi=True)
+    reader.set_scene(0)
+
+    actual = reader.get_image_data("TCZYX", C=[0, 1])
+    expected = BaseReader.get_image_data(reader._implementation, "TCZYX", C=[0, 1])
+
+    np.testing.assert_array_equal(actual, expected)

--- a/bioio_czi/tests/test_pylibczirw_reader.py
+++ b/bioio_czi/tests/test_pylibczirw_reader.py
@@ -340,3 +340,65 @@ def test_ome_metadata_matches_exposed_shape_for_bounding_box_discrepant_czi() ->
     assert pixels.size_z == dim_to_size["Z"]
     assert pixels.size_y == dim_to_size["Y"]
     assert pixels.size_x == dim_to_size["X"]
+
+
+@pytest.mark.parametrize(
+    "filename, set_scene, order, selection",
+    [
+        # Multi-scene TCZYX: T/Z slices, XY sub-ROI, int squeeze, scene origin.
+        ("S=2_4x2_T=2=Z=3_CH=2.czi", "TR1", "TCZYX", {"T": slice(0, 1)}),
+        ("S=2_4x2_T=2=Z=3_CH=2.czi", "TR1", "TCZYX", {"Z": slice(1, 3)}),
+        (
+            "S=2_4x2_T=2=Z=3_CH=2.czi",
+            "TR1",
+            "TCZYX",
+            {"Y": slice(100, 300), "X": slice(50, 400)},
+        ),
+        ("S=2_4x2_T=2=Z=3_CH=2.czi", "TR1", "ZYX", {"T": 0, "C": 1}),
+        (
+            "S=2_4x2_T=2=Z=3_CH=2.czi",
+            "TR1",
+            "CYX",
+            {"T": 1, "Z": 2, "Y": slice(10, 60), "X": slice(20, 90)},
+        ),
+        # Scene 2 has a non-zero XY origin (1584, 851) in the file.
+        ("S=2_4x2_T=2=Z=3_CH=2.czi", "TR2", "TCZYX", {"Z": slice(0, 2)}),
+        # RGB image carries a trailing Samples axis.
+        ("RGB-8bit.czi", "Image:0", "YXS", {"X": slice(0, 50)}),
+    ],
+)
+def test_get_image_data_slicing_reads_region(
+    filename: str,
+    set_scene: str,
+    order: str,
+    selection: dict,
+) -> None:
+    """
+    get_image_data with a hyper-rectangular (int / contiguous-slice) selection
+    must return exactly what the dask path returns, while reading the region
+    directly from the file rather than materializing the whole image.
+    """
+    uri = LOCAL_RESOURCES_DIR / filename
+    reader = Reader(uri)
+    reader.set_scene(set_scene)
+
+    actual = reader.get_image_data(order, **selection)
+    expected = reader.get_image_dask_data(order, **selection).compute()
+
+    assert actual.shape == expected.shape
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_get_image_data_non_slice_defers_to_base() -> None:
+    """
+    Selections that are not expressible as a single hyper-rectangle (e.g. a list
+    of indices) must still return correct data via the base implementation.
+    """
+    uri = LOCAL_RESOURCES_DIR / "S=2_4x2_T=2=Z=3_CH=2.czi"
+    reader = Reader(uri)
+    reader.set_scene("TR1")
+
+    actual = reader.get_image_data("TCZYX", C=[0, 1])
+    expected = reader.get_image_dask_data("TCZYX", C=[0, 1]).compute()
+
+    np.testing.assert_array_equal(actual, expected)


### PR DESCRIPTION
## Summary

Make `get_image_data` serve a **hyper-rectangular selection** by reading only the requested bytes directly from the file, instead of materializing the whole image and slicing it (the base behavior). This gives callers a memory-bounded, fast partial read through the existing API — no new public method.

A selection qualifies when **every** keyword is an `int` or a contiguous `slice` (step 1/None) and **at least one** is a `slice`. Anything else (lists, ranges, strided slices, no keywords) defers to the base implementation unchanged.

## What changed

- **pylibczirw backend** (`pylibczirw_reader/reader.py`): a private `_read_region` opens the CZI **once** and streams only the requested planes, cropping each to the requested XY **ROI at the source**. Derives dims/shape from the bounding boxes without building the per-plane dask graph. Handles per-scene XY origin and the BGR samples axis.
- **aicspylibczi backend** (`aicspylibczi_reader/reader.py`): a private `_read_region` opens the `CziFile` **once** and reads only the requested planes via `read_image` (XY cropped in numpy, since `read_image` has no ROI). Handles mosaic `M` tiles, the `H` axis, begin-index offsets, and `reshape_data`'s dimension pruning.
- **wrapper** (`reader.py`): `get_image_data` delegates to the active backend so the routing is reachable via `bioio_czi.Reader` and `BioImage`.

## Why

`get_image_dask_data(...).compute()` builds a per-plane dask graph and re-opens the file for every YX slice; base `get_image_data` reads the whole image then slices. For partial reads (e.g. tiled/sharded conversion) both are wasteful. This serves the same result by holding the file open and reading just the requested region.

## Validation

For both backends, the routed `get_image_data` output is compared **byte-for-byte** against the established path across the test CZIs — including multi-scene (per-scene XY origin), XY sub-ROIs, int-squeeze/reorder, mosaic `M` tiles (keep / slice / prune), the `H` axis, and RGB (`YXS`). New tests added for both modes. Full suite: 63 passed, 10 (pre-existing) xfailed.

## Notes

- Public API surface is unchanged; only `get_image_data` got smarter.
- The two `_read_region` methods are the natural home for a future public `read_region`, should one be wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
