### PR TITLE
feat: populate stage_position_x/y from CZI scene XML

### DIFF
--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -532,7 +532,9 @@ class Reader(BaseReader):
         metadata.column = standard_metadata.column(self.metadata, czi_scene_index)
         metadata.position_index = standard_metadata.position_index(self.current_scene)
         metadata.row = standard_metadata.row(self.metadata, czi_scene_index)
-
+        metadata.stage_position_x, metadata.stage_position_y = (
+            standard_metadata.scene_stage_position(self.metadata, czi_scene_index)
+        )
         # 3. Finally, total_time_duration is mode-specific, as only aicspylibczi mode
         # has access to the necessary subblock metadata.
         metadata.timelapse_interval = self.time_interval

--- a/bioio_czi/standard_metadata.py
+++ b/bioio_czi/standard_metadata.py
@@ -83,3 +83,35 @@ def row(metadata: Element, current_scene_index: int) -> Optional[str]:
         The row index as a string. Returns None if not found.
     """
     return _row_or_column(metadata, current_scene_index, "row")
+
+
+def scene_stage_position(
+    metadata: Element, current_scene_index: int
+) -> tuple[Optional[float], Optional[float]]:
+    """
+    Extracts the stage center position for the current scene from the CZI XML.
+
+    Returns
+    -------
+    tuple[Optional[float], Optional[float]]
+        (stage_x, stage_y) in microns, or (None, None) if not found.
+    """
+    try:
+        scenes = metadata.findall(
+            "Metadata/Information/Image/Dimensions/S/Scenes/Scene"
+        )
+        for scene in scenes:
+            scene_index = scene.get("Index")
+            if scene_index is not None and int(scene_index) == current_scene_index:
+                center = scene.find("CenterPosition")
+                if center is not None and center.text:
+                    x_str, y_str = center.text.split(",")
+                    return float(x_str), float(y_str)
+    except Exception as exc:
+        log.warning(
+            "Failed to extract stage position for scene %s: %s",
+            current_scene_index,
+            exc,
+            exc_info=True,
+        )
+    return None, None

--- a/bioio_czi/tests/test_standard_metadata.py
+++ b/bioio_czi/tests/test_standard_metadata.py
@@ -38,6 +38,8 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Pixel Size Z": 2.23,
                 "Position Index": 1,
                 "Row": "4",
+                "Stage Position X": 32056.045,
+                "Stage Position Y": 31179.085,
                 "Timelapse": True,
                 "Timelapse Interval": datetime.timedelta(milliseconds=59927.0),
                 "Total Time Duration": datetime.timedelta(milliseconds=59927.0),
@@ -65,6 +67,8 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Pixel Size Z": None,
                 "Position Index": None,
                 "Row": None,
+                "Stage Position X": 43832.037,
+                "Stage Position Y": 14634.984,
                 "Timelapse": False,
                 "Timelapse Interval": None,
                 "Total Time Duration": None,
@@ -119,6 +123,8 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Pixel Size Z": 2.23,
                 "Position Index": 1,
                 "Row": "4",
+                "Stage Position X": 32056.045,
+                "Stage Position Y": 31179.085,
                 "Timelapse": True,
                 "Timelapse Interval": None,  # Available only in aicspylibczi mode
                 "Total Time Duration": None,  # Available only in aicspylibczi mode
@@ -148,6 +154,8 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Pixel Size Z": None,
                 "Position Index": None,
                 "Row": None,
+                "Stage Position X": 43832.037,
+                "Stage Position Y": 14634.984,
                 "Timelapse": False,
                 "Timelapse Interval": None,  # Available only in aicspylibczi mode
                 "Total Time Duration": None,  # Available only in aicspylibczi mode


### PR DESCRIPTION
## Summary

Resolves #106 

Adds `stage_position_x` and `stage_position_y` to standard_metadata.  parses the `CenterPosition` element from the CZI scene XML to extract per-scene stage coordinates in microns. This allows us to build a shared coordinate system across images and locate overlapping FOVS.

This can be used to generate per scene FOVS for multi-scene images:
<img width="1510" height="750" alt="fov_10X_Overview" src="https://github.com/user-attachments/assets/577d9f21-059c-4402-b14d-de1b310f8679" />

And to overlay existing images of different magnifications:
<img width="1171" height="1182" alt="well_B3_detail" src="https://github.com/user-attachments/assets/e2924c2a-476a-40f0-833b-ec08d8b4ff84" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)