### PR TITLE
feat: complete remote CZI reading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ Install bioio-czi alongside bioio:
 
 | Feature                                             | pylibczirw mode | aicspylibczi mode |
 | --------------------------------------------------- | --------------- | ----------------- |
-| Read CZIs from the internet                         | ✅              | ❌                |
+| Read CZIs from the internet                         | ✅              | ✅\*\*\*          |
 | Read single tile from tiled CZI                     | ❌              | ✅                |
 | Read single tile's metadata from tiled CZI          | ❌              | ✅                |
 | Read elapsed time metadata\*                        | ❌              | ✅                |
 | Handle CZIs with different dimensions per scene\*\* | ❌              | ✅                |
 | Read stitched mosaic of a tiled CZI                 | ✅              | ✅                |
 
-The primary difference is that `pylibczirw` supports reading CZIs over the internet but cannot access individual tiles from a tiled CZI. To use `aicspylibczi`, add the `use_aicspylibczi=True` parameter when creating a reader. For example: `from bioio import BioImage; img = BioImage(..., use_aicspylibczi=True)`.
+The primary difference is that `pylibczirw` cannot access individual tiles from a tiled CZI. To use `aicspylibczi`, add the `use_aicspylibczi=True` parameter when creating a reader. For example: `from bioio import BioImage; img = BioImage(..., use_aicspylibczi=True)`.
 
 \*Elapsed time metadata include the following. These are derived from individual subblock metadata.
 
@@ -49,6 +49,8 @@ The primary difference is that `pylibczirw` supports reading CZIs over the inter
 - `BioImage(...).standard_metadata.total_time_duration`
 
 \*\*The underlying pylibczirw reader only exposes per-scene X and Y dimensions. Files that do not have consistent dimensions per scene may be read incorrectly in pylibczirw mode.
+
+\*\*\*Remote reading in `aicspylibczi` mode needs an `aicspylibczi` built with libCZI's curl stream, which is a build-time option. See [Reading remote CZIs](#reading-remote-czis).
 
 ## Example Usage (see full documentation for more examples)
 
@@ -66,7 +68,63 @@ img = BioImage(path)
 print(img.shape)  # (1, 1, 1, 5684, 5925)
 ```
 
-Note: accessing files from the internet is not available in `aicspylibczi` mode.
+### Reading remote CZIs
+
+Both modes read remote CZIs through libCZI's curl-based stream, which issues HTTP
+range requests for just the sub-blocks a read needs instead of downloading the whole
+file. The server must support range requests.
+
+```python
+from bioio import BioImage
+
+url = (
+    "https://allencell.s3.amazonaws.com/aics/hipsc_12x_overview_image_dataset/"
+    "stitchedwelloverviewimagepath/05080558_3500003720_10X_20191220_D3.czi"
+)
+
+img = BioImage(url, use_aicspylibczi=True)
+# Only the bytes covering this window are fetched, not the full 5684x5925 image.
+print(img.get_image_data("YX", C=0, Y=slice(0, 512), X=slice(0, 512)).shape)
+```
+
+Object stores addressed by their own protocol -- `s3://`, `gs://`, `az://` -- are
+supported by asking the matching [fsspec](https://filesystem-spec.readthedocs.io)
+filesystem to presign the object into an https URL, which is then read like any other
+URL. Credentials stay with fsspec and are resolved the way that filesystem normally
+resolves them, so the protocol's fsspec package must be installed (`s3fs`, `gcsfs`,
+`adlfs`, ...):
+
+```python
+img = BioImage("s3://my-bucket/images/my_file.czi")
+
+# Pass filesystem options, e.g. a profile or anonymous access, with fs_kwargs.
+img = BioImage("s3://my-bucket/images/my_file.czi", fs_kwargs={"profile": "my-profile"})
+```
+
+Presigned URLs expire. A URL is generated fresh each time the file is opened, including
+inside dask graphs, so a long-running lazy read will not trip over an expired signature;
+`url_expiration` (seconds, `aicspylibczi` mode) sets how long each one lasts.
+
+In `aicspylibczi` mode, `stream_options` configures the underlying curl stream, for
+example to set a timeout or authenticate to a protected endpoint:
+
+```python
+img = BioImage(
+    "https://example.com/private/image.czi",
+    use_aicspylibczi=True,
+    stream_options={"timeout": 60, "xoauth2_bearer": token},
+)
+```
+
+Remote reading in `aicspylibczi` mode requires an `aicspylibczi` built with libCZI's
+curl stream. Reading a remote CZI with a build that lacks it raises
+`UnsupportedFileFormatError` explaining as much; to check up front:
+
+```python
+from aicspylibczi import remote_reads_available
+
+remote_reads_available()
+```
 
 ### Individual tiles with aicspylibczi
 

--- a/bioio_czi/aicspylibczi_reader/reader.py
+++ b/bioio_czi/aicspylibczi_reader/reader.py
@@ -1,10 +1,12 @@
 import itertools
 import logging
 import xml.etree.ElementTree as ET
+from contextlib import contextmanager
 from copy import copy
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, Hashable, List, Optional, Tuple, Union
+from typing import Any, Dict, Hashable, Iterator, List, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -26,14 +28,27 @@ from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 
 from .. import metadata as metadata_utils
+from .. import remote
 from ..bounding_box import size
 from ..channels import get_channel_names
 from ..pixel_sizes import get_physical_pixel_sizes
 from .subblock_metadata import acquisition_times, time_between_subblocks
 
+try:
+    from aicspylibczi import remote_reads_available
+except ImportError:
+    # aicspylibczi releases before remote read support have no way to read over the
+    # network at all. Reporting that here, rather than failing to import, keeps this
+    # plugin working on older aicspylibczi for the local reads it can still do.
+    def remote_reads_available() -> bool:  # type: ignore[misc]
+        return False
+
+
 ###############################################################################
 
 log = logging.getLogger(__name__)
+
+READER_NAME = "bioio-czi[aicspylibczi mode]"
 
 ###############################################################################
 
@@ -60,6 +75,128 @@ PIXEL_DICT = {
 }
 
 
+@dataclass
+class CziSource:
+    """
+    Everything needed to open one CZI, wherever it lives.
+
+    aicspylibczi holds no file handle between calls, so the reader reopens the CZI
+    for each piece of work it does. This bundles the "how to reopen it" details so
+    they travel together, including into dask graphs -- which is why it stores a
+    filesystem and a path rather than an open handle.
+
+    Remote sources are re-signed on every open rather than caching a URL, so a dask
+    graph that runs long after the reader was constructed cannot trip over an
+    expired signature. For object stores this is local HMAC work, not a round trip.
+
+    Parameters
+    ----------
+    fs: AbstractFileSystem
+        The filesystem holding the image.
+    path: str
+        The protocol-stripped path within ``fs``, e.g. "bucket/key" for
+        "s3://bucket/key".
+    uri: str
+        The image location with its protocol intact. Presigning needs this, because
+        ``path`` has had the protocol stripped off by fsspec.
+    stream_options: Optional[Dict[str, Any]]
+        libCZI stream options, e.g. ``{"timeout": 30}``. Remote sources only.
+        Default: None
+    url_expiration: int
+        Seconds a generated presigned URL stays valid.
+        Default: remote.DEFAULT_URL_EXPIRATION_SECONDS
+    """
+
+    fs: AbstractFileSystem
+    path: str
+    uri: str
+    stream_options: Optional[Dict[str, Any]] = None
+    url_expiration: int = remote.DEFAULT_URL_EXPIRATION_SECONDS
+
+    @classmethod
+    def from_fs(
+        cls,
+        fs: AbstractFileSystem,
+        path: str,
+        **kwargs: Any,
+    ) -> "CziSource":
+        """
+        Build a source from the ``(fs, path)`` pair BioIO readers are handed.
+
+        The protocol is put back onto ``path`` so that object-store paths can be
+        presigned later. Local paths are left alone rather than turned into
+        ``file://`` URIs.
+        """
+        if isinstance(fs, LocalFileSystem) or remote.uri_scheme(path):
+            # A path that still carries its scheme -- which is what fsspec hands
+            # back for http(s) -- is already a URI. Putting the protocol back on
+            # anyway would double it up, e.g. "https://http://host/a.czi".
+            uri = path
+        else:
+            uri = fs.unstrip_protocol(path)
+        return cls(fs=fs, path=path, uri=uri, **kwargs)
+
+    @property
+    def is_remote(self) -> bool:
+        """
+        Whether this CZI is read over the network rather than off local disk.
+        """
+        return remote.is_remote(self.uri)
+
+    @contextmanager
+    def open(self) -> Iterator[CziFile]:
+        """
+        Open the CZI, yielding a ``CziFile`` for the duration of the block.
+
+        Raises
+        ------
+        exceptions.UnsupportedFileFormatError
+            The image is remote but this aicspylibczi build cannot read remote
+            files, or its protocol cannot be turned into an http(s) URL.
+        """
+        if self.is_remote:
+            require_remote_reads(self.uri)
+            if remote.is_http_url(self.uri):
+                url = self.uri
+            else:
+                # Reuse the filesystem the reader already built rather than
+                # reconstructing it (and its credentials) on every open.
+                url = remote.sign_url(
+                    self.fs,
+                    self.path,
+                    uri=self.uri,
+                    reader_name=READER_NAME,
+                    expiration=self.url_expiration,
+                )
+            yield CziFile(url, stream_options=self.stream_options or None)
+        else:
+            with self.fs.open(self.path) as open_resource:
+                yield CziFile(open_resource.f)
+
+
+def require_remote_reads(uri: str) -> None:
+    """
+    Raise unless this aicspylibczi installation can read CZIs over http(s).
+
+    Remote reads need libCZI's curl-based stream, which is a build-time option in
+    aicspylibczi, so a working import is not enough to know they are available.
+
+    Raises
+    ------
+    exceptions.UnsupportedFileFormatError
+        This build was compiled without the curl stream.
+    """
+    if not remote_reads_available():
+        raise exceptions.UnsupportedFileFormatError(
+            READER_NAME,
+            uri,
+            "This aicspylibczi build was compiled without libCZI's curl stream, so "
+            "it cannot read CZIs over the network. Reinstall aicspylibczi from a "
+            "wheel built with remote support, or drop use_aicspylibczi to read this "
+            "image in pylibczirw mode.",
+        )
+
+
 class Reader(BaseReader):
     """
     Wraps the aicspylibczi API to provide the same BioIO Reader plugin for
@@ -67,7 +204,7 @@ class Reader(BaseReader):
 
     Notes
     -----
-    To use this reader, install with: `pip install aicspylibczi>=3.1.1`.
+    To use this reader, install with: `pip install aicspylibczi>=3.3.1`.
     """
 
     NAME = "bioio-czi-aicspylibczi"
@@ -84,23 +221,31 @@ class Reader(BaseReader):
     # they may not need to be used by your reader (i.e. input param is an array)
     _fs: "AbstractFileSystem"
     _path: str
+    # How to reopen the image; see CziSource. _fs and _path are kept alongside it
+    # because BioIO (and its test utilities) expect every reader to expose them.
+    _source: CziSource
 
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
-        if not isinstance(fs, LocalFileSystem):
-            raise exceptions.UnsupportedFileFormatError(
-                "bioio-czi[aicspylibczi mode]",
-                path,
-                "Try not setting use_aicspylibczi?",
-            )
+        source = CziSource.from_fs(
+            fs,
+            path,
+            stream_options=kwargs.get("stream_options"),
+        )
         try:
-            with fs.open(path) as open_resource:
-                CziFile(open_resource.f)
+            with source.open():
                 return True
-        except RuntimeError as e:
+        except exceptions.UnsupportedFileFormatError:
+            # Already explains itself, e.g. a protocol that cannot be presigned.
+            raise
+        except (RuntimeError, OSError) as e:
+            # libCZI reports an unreadable file as a RuntimeError. Reading over the
+            # network adds connection and HTTP failures on top, which arrive as
+            # OSError, and mean "could not fetch" rather than "not a CZI" -- but
+            # either way this reader cannot open the image.
             raise exceptions.UnsupportedFileFormatError(
-                "bioio-czi[aicspylibczi mode]",
-                path,
+                READER_NAME,
+                source.uri,
                 str(e),
             )
 
@@ -110,12 +255,16 @@ class Reader(BaseReader):
         chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
         include_subblock_metadata: bool = False,
         fs_kwargs: Dict[str, Any] = {},
+        stream_options: Optional[Dict[str, Any]] = None,
+        url_expiration: int = remote.DEFAULT_URL_EXPIRATION_SECONDS,
     ):
         """
         Parameters
         ----------
         image: types.PathLike
-            Path to image file to construct Reader for.
+            Path to image file to construct Reader for. May be a local path, an
+            http(s) URL, or an object-store URI such as "s3://bucket/key". See the
+            Notes section for how remote images are read.
         chunk_dims: Union[str, List[str]]
             Which dimensions to create chunks for.
             Default: DEFAULT_CHUNK_DIMS
@@ -128,6 +277,25 @@ class Reader(BaseReader):
         fs_kwargs: Dict[str, Any]
             Any specific keyword arguments to pass to the fsspec-created filesystem.
             Default: {}
+        stream_options: Optional[Dict[str, Any]]
+            libCZI stream options for remote images, e.g. ``{"timeout": 60}`` or
+            ``{"xoauth2_bearer": token}``. Ignored for local images.
+            Default: None
+        url_expiration: int
+            How long, in seconds, a presigned URL generated for an object-store
+            image stays valid. Only relevant for protocols that must be presigned,
+            e.g. "s3://". Reads are issued for as long as this reader (and any dask
+            graph built from it) is in use, so this needs to outlast a read session.
+            Default: remote.DEFAULT_URL_EXPIRATION_SECONDS
+
+        Notes
+        -----
+        Remote images are read by libCZI's curl-based stream, which fetches only the
+        byte ranges it needs rather than downloading the whole file. Protocols other
+        than http(s) are presigned into an https URL by their fsspec filesystem, so
+        credentials are resolved by fsspec in the usual way and never handed to
+        libCZI. This requires an aicspylibczi built with remote support; see
+        :func:`require_remote_reads`.
         """
         # Expand details of provided image
         self._fs, self._path = io_utils.pathlike_to_fs(
@@ -136,13 +304,12 @@ class Reader(BaseReader):
             fs_kwargs=fs_kwargs,
         )
 
-        # Catch non-local file system
-        if not isinstance(self._fs, LocalFileSystem):
-            raise exceptions.UnsupportedFileFormatError(
-                "bioio-czi[aicspylibczi mode]",
-                self._path,
-                "Try not setting use_aicspylibczi?",
-            )
+        self._source = CziSource.from_fs(
+            self._fs,
+            self._path,
+            stream_options=stream_options,
+            url_expiration=url_expiration,
+        )
 
         # Store params
         if isinstance(chunk_dims, str):
@@ -158,7 +325,9 @@ class Reader(BaseReader):
         self._czi_scene_index: Optional[int] = None
 
         # Enforce valid image
-        if not self._is_supported_image(self._fs, self._path):
+        if not self._is_supported_image(
+            self._fs, self._path, stream_options=stream_options
+        ):
             raise exceptions.UnsupportedFileFormatError(
                 self.__class__.__name__, self._path
             )
@@ -166,8 +335,7 @@ class Reader(BaseReader):
     @property
     def mapped_dims(self) -> str:
         if self._mapped_dims is None:
-            with self._fs.open(self._path) as open_resource:
-                czi = CziFile(open_resource.f)
+            with self._source.open() as czi:
                 self._mapped_dims = Reader._fix_czi_dims(czi.dims)
 
         return self._mapped_dims
@@ -197,8 +365,7 @@ class Reader(BaseReader):
             Tuple[str, ...]: Scene names/id
         """
         if self._scenes is None:
-            with self._fs.open(self._path) as open_resource:
-                czi = CziFile(open_resource.f)
+            with self._source.open() as czi:
                 xpath_str = "./Metadata/Information/Image/Dimensions/S/Scenes/Scene"
                 meta_scenes = czi.meta.findall(xpath_str)
                 scene_names: List[str] = []
@@ -333,19 +500,17 @@ class Reader(BaseReader):
 
     @staticmethod
     def _read_chunk_from_image(
-        fs: AbstractFileSystem,
-        path: str,
+        source: CziSource,
         scene: int,
         read_dims: Optional[Dict[str, int]] = None,
     ) -> np.ndarray:
-        return Reader._get_image_data(
-            fs=fs, path=path, scene=scene, read_dims=read_dims
-        )[0]
+        return Reader._get_image_data(source=source, scene=scene, read_dims=read_dims)[
+            0
+        ]
 
     @staticmethod
     def _get_image_data(
-        fs: AbstractFileSystem,
-        path: str,
+        source: CziSource,
         scene: int,
         read_dims: Optional[Dict[str, int]] = None,
     ) -> Tuple[np.ndarray, List[Tuple[str, int]]]:
@@ -355,10 +520,8 @@ class Reader(BaseReader):
 
         Parameters
         ----------
-        fs: AbstractFileSystem
-            The file system to use for reading.
-        path: str
-            The path to the file to read.
+        source: CziSource
+            Where the image lives and how to reopen it.
         scene: int
             The scene index to pull the chunk from.
         read_dims: Optional[Dict[str, int]]
@@ -373,8 +536,7 @@ class Reader(BaseReader):
             The dimension sizes that were returned from the read.
         """
         # Init czi and delegate to the shared single-plane read.
-        with fs.open(path) as open_resource:
-            czi = CziFile(open_resource.f)
+        with source.open() as czi:
             return Reader._read_plane(czi, scene, read_dims)
 
     @staticmethod
@@ -454,8 +616,7 @@ class Reader(BaseReader):
         """
         if self._dims is None:
             order = self.mapped_dims
-            with self._fs.open(self._path) as open_resource:
-                czi = CziFile(open_resource.f)
+            with self._source.open() as czi:
                 dims_shape = Reader._dims_shape_to_scene_dims_shape(
                     czi.get_dims_shape(),
                     self.current_scene_index,
@@ -514,8 +675,7 @@ class Reader(BaseReader):
             spec for d, spec in zip(given_dims, dim_specs) if d in spatial
         )
 
-        with self._fs.open(self._path) as open_resource:
-            czi = CziFile(open_resource.f)
+        with self._source.open() as czi:
             dims_shape = Reader._dims_shape_to_scene_dims_shape(
                 czi.get_dims_shape(),
                 self.current_scene_index,
@@ -698,8 +858,7 @@ class Reader(BaseReader):
             # Add delayed array to lazy arrays at index
             lazy_arrays[np_index] = da.from_delayed(
                 delayed(Reader._read_chunk_from_image)(
-                    fs=self._fs,
-                    path=self._path,
+                    source=self._source,
                     scene=self.current_scene_index,
                     read_dims=this_chunk_read_dims,
                 ),
@@ -772,8 +931,7 @@ class Reader(BaseReader):
         exceptions.UnsupportedFileFormatError
             The file could not be read or is not supported.
         """
-        with self._fs.open(self._path) as open_resource:
-            czi = CziFile(open_resource.f)
+        with self._source.open() as czi:
 
             dims_shape = Reader._dims_shape_to_scene_dims_shape(
                 dims_shape=czi.get_dims_shape(),
@@ -833,8 +991,7 @@ class Reader(BaseReader):
         exceptions.UnsupportedFileFormatError
             The file could not be read or is not supported.
         """
-        with self._fs.open(self._path) as open_resource:
-            czi = CziFile(open_resource.f)
+        with self._source.open() as czi:
             dims_shape = Reader._dims_shape_to_scene_dims_shape(
                 dims_shape=czi.get_dims_shape(),
                 scene_index=self.current_scene_index,
@@ -843,8 +1000,7 @@ class Reader(BaseReader):
 
             # Get image data
             image_data, _ = self._get_image_data(
-                fs=self._fs,
-                path=self._path,
+                source=self._source,
                 scene=self.current_scene_index,
             )
 
@@ -1005,8 +1161,7 @@ class Reader(BaseReader):
 
     def _construct_mosaic_xarray(self, data: types.ArrayLike) -> xr.DataArray:
         # Get max of mosaic positions from lif
-        with self._fs.open(self._path) as open_resource:
-            czi = CziFile(open_resource.f)
+        with self._source.open() as czi:
             dims_shape = Reader._dims_shape_to_scene_dims_shape(
                 dims_shape=czi.get_dims_shape(),
                 scene_index=self.current_scene_index,
@@ -1081,8 +1236,7 @@ class Reader(BaseReader):
         still uses the original plate-wide scene indices.
         """
         if self._czi_scene_index is None:
-            with self._fs.open(self._path) as open_resource:
-                czi = CziFile(open_resource.f)
+            with self._source.open() as czi:
                 self._czi_scene_index = Reader._adjust_scene_index(
                     czi.get_dims_shape(),
                     self.current_scene_index,
@@ -1154,8 +1308,7 @@ class Reader(BaseReader):
         if DimensionNames.MosaicTile not in self.dims.order:
             raise exceptions.UnexpectedShapeError("No mosaic dimension in image.")
 
-        with self._fs.open(self._path) as open_resource:
-            czi = CziFile(open_resource.f)
+        with self._source.open() as czi:
 
             # Default Channel and Time dimensions to 0 to improve
             # worst case read time for large files **only**
@@ -1197,8 +1350,7 @@ class Reader(BaseReader):
         if DimensionNames.MosaicTile not in self.dims.order:
             raise exceptions.UnexpectedShapeError("No mosaic dimension in image.")
 
-        with self._fs.open(self._path) as open_resource:
-            czi = CziFile(open_resource.f)
+        with self._source.open() as czi:
 
             tile_info_to_bboxes = czi.get_all_mosaic_tile_bounding_boxes(
                 S=self.czi_scene_index, **kwargs
@@ -1229,8 +1381,7 @@ class Reader(BaseReader):
             Returns None if extraction fails.
         """
 
-        with self._fs.open(self._path) as open_resource:
-            czi = CziFile(open_resource.f)
+        with self._source.open() as czi:
             return acquisition_times(
                 czi=czi,
                 current_scene=self.czi_scene_index,
@@ -1286,8 +1437,7 @@ class Reader(BaseReader):
             return None
 
         try:
-            with self._fs.open(self._path) as open_resource:
-                czi = CziFile(open_resource.f)
+            with self._source.open() as czi:
                 duration_ms = time_between_subblocks(
                     czi,
                     self.czi_scene_index,

--- a/bioio_czi/pylibczirw_reader/reader.py
+++ b/bioio_czi/pylibczirw_reader/reader.py
@@ -30,12 +30,14 @@ from dask import delayed
 from fsspec.spec import AbstractFileSystem
 from pylibCZIrw import czi
 
-from .. import metadata
+from .. import metadata, remote
 from ..channels import get_channel_names, size
 from ..metadata import UnsupportedMetadataError
 from ..pixel_sizes import get_physical_pixel_sizes
 
 log = logging.getLogger(__name__)
+
+READER_NAME = "bioio-czi[pylibczirw mode]"
 
 PIXEL_DICT = {
     "gray8": np.uint8,
@@ -57,10 +59,22 @@ class Reader(BaseReader):
     Parameters
     ----------
     image: types.PathLike
-        Path to image file to construct Reader for.
+        Path to image file to construct Reader for. May be a local path, an http(s)
+        URL, or an object-store URI such as "s3://bucket/key". See the Notes section
+        for how remote images are read.
     fs_kwargs: Dict[str, Any]
         Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Only used to presign object-store URIs; local paths and http(s) URLs go
+        straight to libCZI.
         Default: {}
+
+    Notes
+    -----
+    Remote images are read by libCZI's curl-based stream, which issues range
+    requests for just the sub-blocks needed rather than downloading the whole file.
+    The server must support range requests. Protocols other than http(s) are
+    presigned into an https URL by their fsspec filesystem, so credentials are
+    resolved by fsspec in the usual way.
     """
 
     NAME = "bioio-czi-pylibczirw"
@@ -99,19 +113,27 @@ class Reader(BaseReader):
             or raises an exception if it is not.
         """
         try:
-            with open(path):
+            with open(path, fs_kwargs=kwargs.get("fs_kwargs")):
                 return True
-        except RuntimeError as e:
+        except exceptions.UnsupportedFileFormatError:
+            # Already explains itself, e.g. a protocol that cannot be presigned.
+            raise
+        except (RuntimeError, OSError) as e:
+            # libCZI reports an unreadable file as a RuntimeError. Reading over the
+            # network adds connection and HTTP failures on top, which arrive as
+            # OSError, and mean "could not fetch" rather than "not a CZI" -- but
+            # either way this reader cannot open the image.
             raise exceptions.UnsupportedFileFormatError(
-                "bioio-czi[pylibczirw mode]",
+                READER_NAME,
                 path,
                 str(e),
             )
 
     def __init__(self, image: types.PathLike, fs_kwargs: Dict[str, Any] = {}) -> None:
         path = str(image)
+        self._fs_kwargs = fs_kwargs
         try:
-            with open(path) as file:
+            with open(path, fs_kwargs=fs_kwargs) as file:
                 self._fs = None  # Unused but required by tests
                 self._path = path
                 self._total_bounding_box = file.total_bounding_box_no_pyramid
@@ -120,8 +142,11 @@ class Reader(BaseReader):
                     file.scenes_bounding_rectangle_no_pyramid
                 )
                 self._czi_scene_indices = sorted(self._scenes_bounding_rectangle.keys())
-        except RuntimeError:
-            raise exceptions.UnsupportedFileFormatError(self.__class__.__name__, path)
+        except (RuntimeError, OSError) as e:
+            # See _is_supported_image for why OSError is caught alongside RuntimeError.
+            raise exceptions.UnsupportedFileFormatError(
+                self.__class__.__name__, path, str(e)
+            )
 
     @property
     def scenes(self) -> Tuple[str, ...]:
@@ -269,7 +294,7 @@ class Reader(BaseReader):
             ), f"Expected {len(indices)} >= {len(index_dims)}."
             # E.g., plane = {'T': 0, 'C': 1, 'Z': 2}
             plane = {d: indices[i] for i, d in enumerate(index_dims)}
-            with open(self._path) as file:
+            with open(self._path, fs_kwargs=self._fs_kwargs) as file:
                 result = file.read(scene=current_scene, plane=plane, roi=current_roi)
             # result.shape is (Y, X, 1) or (Y, X, 3) depending on whether it's RGB
             # or grayscale. We want to return (Y, X) or (Y, X, 3).
@@ -467,7 +492,7 @@ class Reader(BaseReader):
         ]
 
         out: Optional[np.ndarray] = None
-        with open(self._path) as file:
+        with open(self._path, fs_kwargs=self._fs_kwargs) as file:
             for combo in itertools.product(*enumerated):
                 out_pos = tuple(pos for pos, _idx in combo if pos is not None)
                 plane = {d: idx for (d, (_pos, idx)) in zip(cullable_dims, combo)}
@@ -664,7 +689,7 @@ class Reader(BaseReader):
         https://docs.python.org/3/library/xml.html#xml-vulnerabilities
         """
         if self._metadata is None:
-            with open(self._path) as file:
+            with open(self._path, fs_kwargs=self._fs_kwargs) as file:
                 self._metadata = ET.fromstring(file.raw_metadata)
         return self._metadata
 
@@ -703,11 +728,33 @@ class Reader(BaseReader):
         return None
 
 
-def open(filepath: str) -> ContextManager[czi.CziReader]:
+def open(
+    filepath: str, fs_kwargs: Optional[Dict[str, Any]] = None
+) -> ContextManager[czi.CziReader]:
     """
-    Wrapper around czi.open_czi to provide type hinting that clarifies the result
-    is a czi.CziReader
+    Open a CZI wherever it lives, local or remote.
+
+    Also wraps czi.open_czi to provide type hinting that clarifies the result is a
+    czi.CziReader.
+
+    Parameters
+    ----------
+    filepath: str
+        A local path, an http(s) URL, or an object-store URI such as
+        "s3://bucket/key".
+    fs_kwargs: Optional[Dict[str, Any]]
+        Keyword arguments for the fsspec filesystem used to presign object-store
+        URIs. Ignored for local paths and http(s) URLs.
+        Default: None
+
+    Notes
+    -----
+    Remote images are read through libCZI's curl-based stream, which fetches only
+    the byte ranges it needs rather than downloading the whole file. Protocols
+    other than http(s) are presigned into an https URL first, so credentials are
+    resolved by fsspec and never handed to libCZI.
     """
-    if filepath.startswith("http") or filepath.startswith("https"):
-        return czi.open_czi(filepath, czi.ReaderFileInputTypes.Curl)
+    if remote.is_remote(filepath):
+        url = remote.resolve_url(filepath, reader_name=READER_NAME, fs_kwargs=fs_kwargs)
+        return czi.open_czi(url, czi.ReaderFileInputTypes.Curl)
     return czi.open_czi(filepath)

--- a/bioio_czi/reader.py
+++ b/bioio_czi/reader.py
@@ -95,11 +95,12 @@ class Reader(BaseReader):
         Parameters
         ----------
         image: types.PathLike
-            Path to image file.
+            Path to image file. May be a local path, an http(s) URL, or an
+            object-store URI such as "s3://bucket/key". See the Notes section for
+            how remote images are read.
         use_aicspylibczi: bool
             Read CZIs with the aicspylibczi library. Use aicspylibczi if you want to
-            read individual tiles from a scene. However, aicspylibczi cannot read files
-            over the internet. Default: False
+            read individual tiles from a scene. Default: False
         chunk_dims: Union[str, List[str]]
             Ignored unless use_aicspylibczi is True.
             Which dimensions to create chunks for.
@@ -112,9 +113,30 @@ class Reader(BaseReader):
             Whether to append metadata from the subblocks to the rest of the embeded
             metadata.
         fs_kwargs: Dict[str, Any]
-            Ignored unless use_aicspylibczi is True.
-            Any specific keyword arguments to pass to the fsspec-created filesystem.
+            Any specific keyword arguments to pass to the fsspec-created filesystem,
+            which is used to presign object-store URIs.
             Default: {}
+        stream_options: Optional[Dict[str, Any]]
+            Ignored unless use_aicspylibczi is True.
+            libCZI stream options for remote images, e.g. {"timeout": 60} or
+            {"xoauth2_bearer": token}. Ignored for local images.
+            Default: None
+        url_expiration: int
+            Ignored unless use_aicspylibczi is True.
+            How long, in seconds, a presigned URL generated for an object-store image
+            stays valid.
+            Default: bioio_czi.remote.DEFAULT_URL_EXPIRATION_SECONDS
+
+        Notes
+        -----
+        Both modes read remote images with libCZI's curl-based stream, which fetches
+        only the byte ranges it needs rather than downloading the whole file, so the
+        server must support range requests. Protocols other than http(s) are
+        presigned into an https URL by their fsspec filesystem, so credentials are
+        resolved by fsspec in the usual way.
+
+        Remote reading in aicspylibczi mode additionally requires an aicspylibczi
+        built with libCZI's curl stream, which is a build-time option.
         """
         if use_aicspylibczi:
             self._implementation = AicsPyLibCziReader(image, **kwargs)

--- a/bioio_czi/remote.py
+++ b/bioio_czi/remote.py
@@ -1,0 +1,208 @@
+"""
+Locate CZIs that live somewhere other than the local filesystem.
+
+Both backends read remote CZIs the same way: libCZI's curl-based stream pulls byte
+ranges over http(s) directly, so only the sub-blocks actually needed cross the
+network and no bytes flow through Python. pylibCZIrw exposes this as
+``ReaderFileInputTypes.Curl``; aicspylibczi accepts an http/https URL in place of a
+filename.
+
+Object stores addressed by their own protocol -- ``s3://``, ``gs://``, ``az://`` --
+are supported by asking the matching fsspec filesystem to presign the object into an
+https URL, which is then handed to libCZI like any other URL. This keeps the fast
+range-request read path rather than downloading the whole file, and means
+credentials stay with fsspec.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+import fsspec
+from bioio_base import exceptions, types
+from fsspec.spec import AbstractFileSystem
+
+log = logging.getLogger(__name__)
+
+# Schemes libCZI's curl stream reads natively.
+HTTP_SCHEMES = frozenset({"http", "https"})
+
+# Schemes that address the local filesystem rather than a network location.
+LOCAL_SCHEMES = frozenset({"", "file", "local"})
+
+# Object-store schemes we expect to be able to presign. This list is only used to
+# make error messages actionable: any non-local protocol whose fsspec filesystem
+# implements ``sign`` will work, whether or not it is named here.
+KNOWN_OBJECT_STORE_SCHEMES = ("s3", "gs", "gcs", "az", "abfs", "abfss", "adl")
+
+# How long a generated presigned URL stays valid. libCZI issues range requests for
+# the whole life of a reader -- and, in aicspylibczi mode, for the life of any dask
+# graph built from it -- so this needs to outlast a full read session rather than a
+# single request.
+DEFAULT_URL_EXPIRATION_SECONDS = 3600
+
+
+def uri_scheme(image: types.PathLike) -> str:
+    """
+    Return the URI scheme of ``image``, or "" if it names a local path.
+
+    Parameters
+    ----------
+    image: types.PathLike
+        A path or URI, as given by the caller.
+
+    Returns
+    -------
+    scheme: str
+        The lowercased scheme, e.g. "s3" for "s3://bucket/key". "" for local paths.
+    """
+    if isinstance(image, Path):
+        return ""
+    scheme = urlparse(str(image)).scheme.lower()
+    # A single-character scheme is a Windows drive letter ("C:\\images\\a.czi"),
+    # not a protocol.
+    return "" if len(scheme) < 2 else scheme
+
+
+def is_http_url(image: types.PathLike) -> bool:
+    """
+    Whether ``image`` is an http/https URL, which libCZI can read as-is.
+    """
+    return uri_scheme(image) in HTTP_SCHEMES
+
+
+def is_local(image: types.PathLike) -> bool:
+    """
+    Whether ``image`` names a file on the local filesystem.
+    """
+    return uri_scheme(image) in LOCAL_SCHEMES
+
+
+def is_remote(image: types.PathLike) -> bool:
+    """
+    Whether ``image`` must be reached over the network.
+
+    Returns True both for http(s) URLs and for object-store protocols such as
+    ``s3://``, which are presigned into http(s) URLs by :func:`resolve_url`.
+    """
+    return not is_local(image)
+
+
+def resolve_url(
+    image: types.PathLike,
+    *,
+    reader_name: str,
+    expiration: int = DEFAULT_URL_EXPIRATION_SECONDS,
+    fs_kwargs: Optional[Dict[str, Any]] = None,
+) -> str:
+    """
+    Return an http(s) URL that libCZI's curl stream can read ``image`` from.
+
+    Parameters
+    ----------
+    image: types.PathLike
+        A remote URI. http(s) URLs are returned unchanged; any other protocol is
+        presigned by its fsspec filesystem.
+    reader_name: str
+        Name of the calling reader, used in error messages.
+    expiration: int
+        Seconds a generated presigned URL stays valid.
+        Default: DEFAULT_URL_EXPIRATION_SECONDS
+    fs_kwargs: Optional[Dict[str, Any]]
+        Keyword arguments for the fsspec filesystem used to presign.
+        Default: None
+
+    Returns
+    -------
+    url: str
+        An http or https URL.
+
+    Raises
+    ------
+    exceptions.UnsupportedFileFormatError
+        The protocol has no fsspec implementation installed, or that
+        implementation cannot presign.
+    ValueError
+        ``image`` is a local path, so there is no URL to resolve.
+    """
+    uri = str(image)
+    if is_http_url(uri):
+        return uri
+    if is_local(uri):
+        raise ValueError(f"{uri!r} is a local path, so it has no remote URL.")
+
+    scheme = uri_scheme(uri)
+    try:
+        fs, key = fsspec.core.url_to_fs(uri, **(fs_kwargs or {}))
+    except ImportError as exc:
+        raise exceptions.UnsupportedFileFormatError(
+            reader_name,
+            uri,
+            f"Reading '{scheme}://' paths needs the fsspec filesystem for that "
+            f"protocol to be installed: {exc}",
+        )
+    return sign_url(fs, key, uri=uri, reader_name=reader_name, expiration=expiration)
+
+
+def sign_url(
+    fs: AbstractFileSystem,
+    path: str,
+    *,
+    uri: str,
+    reader_name: str,
+    expiration: int = DEFAULT_URL_EXPIRATION_SECONDS,
+) -> str:
+    """
+    Presign ``path`` on an already-constructed filesystem into an https URL.
+
+    Callers that already hold a filesystem should prefer this over
+    :func:`resolve_url` so the filesystem (and its credentials) are not rebuilt.
+
+    Parameters
+    ----------
+    fs: AbstractFileSystem
+        The filesystem holding ``path``.
+    path: str
+        The protocol-stripped path within ``fs``, e.g. "bucket/key".
+    uri: str
+        The original URI including its protocol, used in error messages.
+    reader_name: str
+        Name of the calling reader, used in error messages.
+    expiration: int
+        Seconds the presigned URL stays valid.
+        Default: DEFAULT_URL_EXPIRATION_SECONDS
+
+    Returns
+    -------
+    url: str
+        An http or https URL.
+
+    Raises
+    ------
+    exceptions.UnsupportedFileFormatError
+        ``fs`` cannot presign, or signed to something libCZI cannot read.
+    """
+    scheme = uri_scheme(uri)
+    try:
+        url = fs.sign(path, expiration=expiration)
+    except NotImplementedError:
+        raise exceptions.UnsupportedFileFormatError(
+            reader_name,
+            uri,
+            f"The fsspec filesystem for '{scheme}://' cannot generate presigned "
+            "URLs, which is how this reader hands remote files to libCZI. Pass an "
+            "http/https URL instead, or use a protocol that supports signing "
+            f"({', '.join(KNOWN_OBJECT_STORE_SCHEMES)}).",
+        )
+
+    if not is_http_url(url):
+        raise exceptions.UnsupportedFileFormatError(
+            reader_name,
+            uri,
+            f"The fsspec filesystem for '{scheme}://' signed to {url!r}, which is "
+            "not an http/https URL and so cannot be read by libCZI.",
+        )
+
+    log.debug("Presigned %s for reading over http", uri)
+    return url

--- a/bioio_czi/tests/conftest.py
+++ b/bioio_czi/tests/conftest.py
@@ -1,3 +1,91 @@
+import functools
+import http.server
+import io
+import os
 import pathlib
+import re
+import threading
+from typing import Any, BinaryIO, Iterator, Optional
+
+import pytest
 
 LOCAL_RESOURCES_DIR = pathlib.Path(__file__).parent / "resources"
+
+
+class _RangeRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """
+    A static file handler that honors ``Range`` requests.
+
+    libCZI reads a remote CZI by asking for the byte ranges holding the sub-blocks
+    it needs, so the stock handler -- which only ever sends whole files -- cannot
+    stand in for a real image server.
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    def send_head(self) -> Optional[BinaryIO]:
+        path = self.translate_path(self.path)
+        try:
+            handle = open(path, "rb")
+        except OSError:
+            self.send_error(404, "File not found")
+            return None
+
+        size = os.fstat(handle.fileno()).st_size
+        range_header = self.headers.get("Range")
+        if range_header is None:
+            body: BinaryIO = handle
+            length = size
+            status = 200
+        else:
+            match = re.fullmatch(r"bytes=(\d+)-(\d*)", range_header.strip())
+            if match is None:
+                handle.close()
+                self.send_error(416, f"Unsupported range: {range_header}")
+                return None
+            start = int(match.group(1))
+            end = min(int(match.group(2)) if match.group(2) else size - 1, size - 1)
+            if start > end:
+                handle.close()
+                self.send_error(416, f"Range not satisfiable: {range_header}")
+                return None
+            with handle:
+                handle.seek(start)
+                body = io.BytesIO(handle.read(end - start + 1))
+            length = end - start + 1
+            status = 206
+
+        self.send_response(status)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(length))
+        self.send_header("Accept-Ranges", "bytes")
+        if status == 206:
+            self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
+        self.end_headers()
+        return body
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Keep the test output readable; every read makes several requests.
+        pass
+
+
+@pytest.fixture(scope="session")
+def local_http_server() -> Iterator[str]:
+    """
+    Serve the test resources over http, with range support, on localhost.
+
+    Yields the base URL, e.g. "http://127.0.0.1:54321", so tests can read the same
+    resource files over the network path that a remote image takes.
+    """
+    handler = functools.partial(
+        _RangeRequestHandler, directory=str(LOCAL_RESOURCES_DIR)
+    )
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/bioio_czi/tests/test_aicspylibczi_reader.py
+++ b/bioio_czi/tests/test_aicspylibczi_reader.py
@@ -12,7 +12,9 @@ from bioio_base import dimensions, exceptions, test_utilities
 from dateutil import parser
 
 from bioio_czi import Reader
+from bioio_czi.aicspylibczi_reader import reader as aicspylibczi_reader
 from bioio_czi.aicspylibczi_reader.reader import Reader as AicsPyLibCziReader
+from bioio_czi.aicspylibczi_reader.reader import remote_reads_available
 
 from .conftest import LOCAL_RESOURCES_DIR
 
@@ -221,17 +223,43 @@ def test_czi_reader(
     )
 
 
-@pytest.mark.xfail(
-    raises=exceptions.UnsupportedFileFormatError,
-    reason="Do not support remote CZI reading in aicspylibczi mode",
+REMOTE_URL = (
+    "https://allencell.s3.amazonaws.com/aics/hipsc_12x_overview_image_dataset/"
+    "stitchedwelloverviewimagepath/05080558_3500003720_10X_20191220_D3.czi"
 )
-def test_czi_reader_remote_xfail() -> None:
-    # Construct full filepath
-    uri = (
-        "https://allencell.s3.amazonaws.com/aics/hipsc_12x_overview_image_dataset/"
-        "stitchedwelloverviewimagepath/05080558_3500003720_10X_20191220_D3.czi"
-    )
-    Reader(uri, use_aicspylibczi=True)
+
+
+@pytest.mark.skipif(
+    not remote_reads_available(),
+    reason="This aicspylibczi build was compiled without libCZI's curl stream",
+)
+def test_czi_reader_remote() -> None:
+    reader = Reader(REMOTE_URL, use_aicspylibczi=True)
+
+    assert reader.dims.order == "HCYX"
+    assert reader.shape == (1, 1, 5684, 5925)
+    assert reader.physical_pixel_sizes.X == pytest.approx(1.0833333333333333)
+    assert reader.metadata.tag == "ImageDocument"
+
+    # Reads are served by range requests, so asking for a window pulls only the
+    # sub-blocks covering it rather than the whole 5684x5925 image.
+    window = reader.get_image_data("YX", C=0, Y=slice(0, 32), X=slice(0, 32))
+    assert window.shape == (32, 32)
+    assert window.dtype == np.uint16
+
+    # The same read through the dask path, which reopens the image inside the graph.
+    assert np.array_equal(np.asarray(reader.dask_data[0, 0, :32, :32]), window)
+
+
+def test_czi_reader_remote_without_curl_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Remote reads are a build-time option in aicspylibczi, so a build without them
+    # has to say so rather than fail somewhere inside libCZI.
+    monkeypatch.setattr(aicspylibczi_reader, "remote_reads_available", lambda: False)
+
+    with pytest.raises(exceptions.UnsupportedFileFormatError, match="curl stream"):
+        Reader(REMOTE_URL, use_aicspylibczi=True)
 
 
 def _normalize_entries(entries: List[dict[str, Any]]) -> List[dict[str, int | str]]:

--- a/bioio_czi/tests/test_pylibczirw_reader.py
+++ b/bioio_czi/tests/test_pylibczirw_reader.py
@@ -1,11 +1,14 @@
+import contextlib
 import xml.etree.ElementTree as ET
-from typing import List, Tuple
+from typing import Any, ContextManager, List, Tuple
 
 import numpy as np
 import pytest
 from bioio_base import dimensions, exceptions, test_utilities
+from pylibCZIrw import czi
 
 from bioio_czi import Reader
+from bioio_czi.pylibczirw_reader import reader as pylibczirw_reader
 
 from .conftest import LOCAL_RESOURCES_DIR
 
@@ -199,6 +202,58 @@ def test_czi_reader_remote(url: str, expected_shape: Tuple[int]) -> None:
     # Construct full filepath
     reader = Reader(url)
     assert reader.shape == expected_shape
+
+    # Pixels come back too, without the whole 5684x5925 image crossing the network:
+    # libCZI asks for the byte ranges covering the requested window.
+    window = reader.get_image_data("YX", Y=slice(0, 32), X=slice(0, 32))
+    assert window.shape == (32, 32)
+    assert window.dtype == np.uint16
+
+
+def test_open_presigns_object_store_uris(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Object-store URIs cannot be handed to libCZI directly, so they are presigned
+    # into an https URL first and then read over the same curl stream as any URL.
+    # Both halves are faked here so the test needs no credentials and no network.
+    opened: List[Tuple[str, Tuple[Any, ...]]] = []
+
+    def fake_resolve_url(image: str, **kwargs: Any) -> str:
+        assert image == "s3://bucket/prefix/image.czi"
+        return "https://bucket.s3.amazonaws.com/prefix/image.czi?signature=abc"
+
+    def fake_open_czi(filepath: str, *args: Any) -> ContextManager[Any]:
+        opened.append((filepath, args))
+        return contextlib.nullcontext("czi-reader")
+
+    monkeypatch.setattr(pylibczirw_reader.remote, "resolve_url", fake_resolve_url)
+    monkeypatch.setattr(pylibczirw_reader.czi, "open_czi", fake_open_czi)
+
+    with pylibczirw_reader.open("s3://bucket/prefix/image.czi"):
+        pass
+
+    assert opened == [
+        (
+            "https://bucket.s3.amazonaws.com/prefix/image.czi?signature=abc",
+            (czi.ReaderFileInputTypes.Curl,),
+        )
+    ]
+
+
+def test_open_reads_local_paths_off_disk(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The counterpart to the test above: a local path must not be routed through
+    # the curl stream, which would turn a plain file read into a failed URL fetch.
+    opened: List[Tuple[str, Tuple[Any, ...]]] = []
+
+    def fake_open_czi(filepath: str, *args: Any) -> ContextManager[Any]:
+        opened.append((filepath, args))
+        return contextlib.nullcontext("czi-reader")
+
+    monkeypatch.setattr(pylibczirw_reader.czi, "open_czi", fake_open_czi)
+
+    path = str(LOCAL_RESOURCES_DIR / "s_1_t_1_c_1_z_1.czi")
+    with pylibczirw_reader.open(path):
+        pass
+
+    assert opened == [(path, ())]
 
 
 @pytest.mark.parametrize(

--- a/bioio_czi/tests/test_remote.py
+++ b/bioio_czi/tests/test_remote.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pathlib
+from typing import Any, Optional, Tuple
+
+import numpy as np
+import pytest
+from bioio_base import exceptions, types
+from fsspec.implementations.local import LocalFileSystem
+
+from bioio_czi import Reader, remote
+from bioio_czi.aicspylibczi_reader.reader import CziSource, remote_reads_available
+
+from .conftest import LOCAL_RESOURCES_DIR
+
+READER_NAME = "test-reader"
+
+HTTPS_URL = "https://example.com/data/image.czi"
+S3_URI = "s3://bucket/prefix/image.czi"
+
+
+class FakeObjectStore:
+    """
+    Stand-in for an object-store filesystem, so these tests need no credentials.
+
+    Only the two methods :mod:`bioio_czi.remote` uses are implemented.
+    """
+
+    def __init__(
+        self,
+        protocol: str = "s3",
+        signed: Optional[str] = None,
+        sign_error: Optional[Exception] = None,
+    ) -> None:
+        self.protocol = protocol
+        self._signed = signed
+        self._sign_error = sign_error
+        self.sign_calls: list[Tuple[str, int]] = []
+
+    def unstrip_protocol(self, path: str) -> str:
+        return f"{self.protocol}://{path}"
+
+    def sign(self, path: str, expiration: int = 100, **kwargs: Any) -> str:
+        self.sign_calls.append((path, expiration))
+        if self._sign_error is not None:
+            raise self._sign_error
+        assert self._signed is not None
+        return self._signed
+
+
+@pytest.mark.parametrize(
+    "image, expected_scheme, expected_http, expected_remote",
+    [
+        (pathlib.Path("/images/a.czi"), "", False, False),
+        ("/images/a.czi", "", False, False),
+        # A single letter before the colon is a Windows drive, not a protocol.
+        ("C:\\images\\a.czi", "", False, False),
+        ("file:///images/a.czi", "file", False, False),
+        (HTTPS_URL, "https", True, True),
+        ("http://example.com/a.czi", "http", True, True),
+        # Schemes are matched case-insensitively.
+        ("HTTPS://example.com/a.czi", "https", True, True),
+        (S3_URI, "s3", False, True),
+        ("gs://bucket/a.czi", "gs", False, True),
+    ],
+)
+def test_uri_classification(
+    image: types.PathLike,
+    expected_scheme: str,
+    expected_http: bool,
+    expected_remote: bool,
+) -> None:
+    assert remote.uri_scheme(image) == expected_scheme
+    assert remote.is_http_url(image) is expected_http
+    assert remote.is_remote(image) is expected_remote
+    assert remote.is_local(image) is not expected_remote
+
+
+def test_resolve_url_passes_http_through() -> None:
+    # An http(s) URL is what libCZI wants already, so it is handed over untouched
+    # rather than round-tripped through a filesystem.
+    assert remote.resolve_url(HTTPS_URL, reader_name=READER_NAME) == HTTPS_URL
+
+
+def test_resolve_url_rejects_local_path() -> None:
+    with pytest.raises(ValueError):
+        remote.resolve_url("/images/a.czi", reader_name=READER_NAME)
+
+
+def test_resolve_url_signs_object_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    fs = FakeObjectStore(signed=f"{HTTPS_URL}?signature=abc")
+    monkeypatch.setattr(
+        remote.fsspec.core,
+        "url_to_fs",
+        lambda uri, **kwargs: (fs, "bucket/prefix/image.czi"),
+    )
+
+    url = remote.resolve_url(S3_URI, reader_name=READER_NAME, expiration=42)
+
+    assert url == f"{HTTPS_URL}?signature=abc"
+    assert fs.sign_calls == [("bucket/prefix/image.czi", 42)]
+
+
+def test_resolve_url_reports_missing_filesystem(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_import_error(uri: str, **kwargs: Any) -> Any:
+        raise ImportError("Install s3fs to access S3")
+
+    monkeypatch.setattr(remote.fsspec.core, "url_to_fs", raise_import_error)
+
+    with pytest.raises(exceptions.UnsupportedFileFormatError, match="s3fs"):
+        remote.resolve_url(S3_URI, reader_name=READER_NAME)
+
+
+def test_sign_url_reports_unsignable_filesystem() -> None:
+    fs = FakeObjectStore(sign_error=NotImplementedError())
+
+    with pytest.raises(exceptions.UnsupportedFileFormatError, match="presigned"):
+        remote.sign_url(fs, "bucket/key", uri=S3_URI, reader_name=READER_NAME)
+
+
+def test_sign_url_rejects_non_http_signature() -> None:
+    # A filesystem that "signs" to something libCZI cannot fetch is a bug we want
+    # reported at the reader, not a confusing failure inside libCZI.
+    fs = FakeObjectStore(signed="s3://bucket/prefix/image.czi?signature=abc")
+
+    with pytest.raises(exceptions.UnsupportedFileFormatError, match="not an http"):
+        remote.sign_url(fs, "bucket/key", uri=S3_URI, reader_name=READER_NAME)
+
+
+@pytest.mark.parametrize(
+    "path, expected_uri, expected_remote",
+    [
+        (HTTPS_URL, HTTPS_URL, True),
+        # fsspec hands http(s) paths back with their scheme intact; putting the
+        # protocol back on would double it up ("https://http://...").
+        ("http://example.com/a.czi", "http://example.com/a.czi", True),
+        (
+            "https://example.com/a.czi?versionId=xyz",
+            "https://example.com/a.czi?versionId=xyz",
+            True,
+        ),
+    ],
+)
+def test_czi_source_from_http_filesystem(
+    path: str, expected_uri: str, expected_remote: bool
+) -> None:
+    source = CziSource.from_fs(FakeObjectStore(protocol="https"), path)
+
+    assert source.uri == expected_uri
+    assert source.is_remote is expected_remote
+
+
+def test_czi_source_from_object_store_filesystem() -> None:
+    # Object-store paths arrive protocol-stripped, so the protocol is put back on
+    # in order to presign later.
+    source = CziSource.from_fs(FakeObjectStore(), "bucket/prefix/image.czi")
+
+    assert source.uri == S3_URI
+    assert source.is_remote is True
+
+
+# The tests below serve real CZIs over http from localhost, which only exercises
+# the aicspylibczi backend: pylibCZIrw validates URLs with the ``validators``
+# package, which rejects hostnames with no TLD ("http://localhost:8000/a.czi"),
+# and its curl reader stalls on a loopback IP without ever opening a connection.
+# Remote reading in pylibczirw mode is covered against a real server in
+# test_pylibczirw_reader.py instead.
+requires_remote_reads = pytest.mark.skipif(
+    not remote_reads_available(),
+    reason="This aicspylibczi build was compiled without libCZI's curl stream",
+)
+
+
+@requires_remote_reads
+def test_reader_over_http_matches_local(local_http_server: str) -> None:
+    # The same bytes served over http must produce the same image as reading off
+    # disk, metadata included.
+    filename = "s_1_t_1_c_1_z_1.czi"
+    local = Reader(LOCAL_RESOURCES_DIR / filename, use_aicspylibczi=True)
+    over_http = Reader(f"{local_http_server}/{filename}", use_aicspylibczi=True)
+
+    assert over_http.scenes == local.scenes
+    assert over_http.dims.order == local.dims.order
+    assert over_http.shape == local.shape
+    assert over_http.channel_names == local.channel_names
+    assert over_http.physical_pixel_sizes == local.physical_pixel_sizes
+    np.testing.assert_array_equal(over_http.data, local.data)
+    # The delayed path reopens the image inside the dask graph, so it locates the
+    # remote image separately from the eager path above.
+    np.testing.assert_array_equal(over_http.dask_data.compute(), local.data)
+
+
+@requires_remote_reads
+def test_reader_over_http_reads_sub_region(local_http_server: str) -> None:
+    # Sub-region reads are the point of reading over range requests, so check one
+    # matches the equivalent local read rather than only that it has the right shape.
+    filename = "s_3_t_1_c_3_z_5.czi"
+    local = Reader(LOCAL_RESOURCES_DIR / filename, use_aicspylibczi=True)
+    over_http = Reader(f"{local_http_server}/{filename}", use_aicspylibczi=True)
+    over_http.set_scene(1)
+    local.set_scene(1)
+
+    np.testing.assert_array_equal(
+        over_http.get_image_data("YX", C=1, Z=2, Y=slice(0, 32), X=slice(0, 32)),
+        local.get_image_data("YX", C=1, Z=2, Y=slice(0, 32), X=slice(0, 32)),
+    )
+
+
+@requires_remote_reads
+def test_reader_reports_missing_remote_image(local_http_server: str) -> None:
+    with pytest.raises((FileNotFoundError, exceptions.UnsupportedFileFormatError)):
+        Reader(f"{local_http_server}/no-such-image.czi", use_aicspylibczi=True)
+
+
+@requires_remote_reads
+def test_reader_rejects_remote_non_czi(local_http_server: str) -> None:
+    with pytest.raises(exceptions.UnsupportedFileFormatError):
+        Reader(f"{local_http_server}/s_1_t_1_c_1_z_1.ome.tiff", use_aicspylibczi=True)
+
+
+@pytest.mark.parametrize("use_aicspylibczi", [False, True])
+def test_reader_reads_object_store_uri(use_aicspylibczi: bool) -> None:
+    # The full presign path against a real object store: fsspec turns the s3:// URI
+    # into an https URL and libCZI range-reads it. The bucket is public, so this
+    # reads anonymously rather than needing credentials in CI.
+    pytest.importorskip("s3fs", reason="s3fs is needed to presign 's3://' URIs")
+    if use_aicspylibczi and not remote_reads_available():
+        pytest.skip("This aicspylibczi build was compiled without libCZI's curl stream")
+
+    uri = (
+        "s3://allencell/aics/hipsc_12x_overview_image_dataset/"
+        "stitchedwelloverviewimagepath/05080558_3500003720_10X_20191220_D3.czi"
+    )
+    reader = Reader(uri, use_aicspylibczi=use_aicspylibczi, fs_kwargs={"anon": True})
+
+    assert reader.shape[-2:] == (5684, 5925)
+    window = reader.get_image_data("YX", Y=slice(0, 32), X=slice(0, 32))
+    assert window.shape == (32, 32)
+
+
+def test_czi_source_from_local_filesystem() -> None:
+    path = str(LOCAL_RESOURCES_DIR / "s_1_t_1_c_1_z_1.czi")
+    source = CziSource.from_fs(LocalFileSystem(), path)
+
+    # Local paths stay as they are rather than becoming file:// URIs.
+    assert source.uri == path
+    assert source.is_remote is False
+    with source.open() as czi:
+        assert czi.dims == "BCYX"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
+  # Reading remote CZIs in aicspylibczi mode needs libCZI's curl stream, added in
+  # bioio-devs/aicspylibczi#135. Raise this pin once that ships; until then the
+  # reader detects at runtime whether the installed build has it.
   "aicspylibczi>=3.2.1",
   "aiohttp",
   "bioio-base>=3.4.0",
@@ -60,6 +63,10 @@ test = [
   "pytest>=5.4.3",
   "pytest-cov>=2.9.0",
   "pytest-raises>=0.11",
+  # Presigning "s3://" URIs is done by fsspec, so reading one end to end needs the
+  # S3 filesystem installed. Not a runtime dependency: users install the filesystem
+  # for whichever object store they read from.
+  "s3fs",
 ]
 
 # entry points


### PR DESCRIPTION
Closes #112. Depends on bioio-devs/aicspylibczi#135 for the aicspylibczi half.

## What this does

Remote reading was half-wired. pylibczirw mode dispatched `http`/`https` paths to libCZI's curl stream through an untested, undocumented shim; aicspylibczi mode rejected every non-local path outright.

Both backends now read remote CZIs through libCZI's curl-based stream, which issues range requests for just the sub-blocks a read needs instead of downloading the file. Object stores addressed by their own protocol (`s3://`, `gs://`, `az://`) are presigned into an https URL by their fsspec filesystem and then read like any other URL — so credentials stay with fsspec, are resolved the way that filesystem normally resolves them, and never reach libCZI.

```python
img = BioImage("s3://my-bucket/images/my_file.czi", use_aicspylibczi=True)
img.get_image_data("YX", C=0, Y=slice(0, 512), X=slice(0, 512))  # fetches only this window
```

## Changes

- **`bioio_czi/remote.py` (new)** — locating and presigning, shared by both backends.
- **aicspylibczi backend** — `CziSource` bundles "how to reopen this image" and is threaded through every read site, including into dask graphs. Remote sources are re-signed on each open rather than caching a URL, so a graph computed long after the reader was built cannot trip over an expired signature. New `stream_options` and `url_expiration` kwargs.
- **pylibczirw backend** — all remote URIs route through presigning, not just a `startswith("http")` check; `fs_kwargs` reaches the calls that need it.
- **Error handling** — `_is_supported_image` in both backends catches `OSError` (network/HTTP failures) alongside `RuntimeError` (unreadable file), and no longer drops the error text on the floor.
- **Capability detection** — the curl stream is a build-time option in aicspylibczi, so the reader checks at runtime and raises an `UnsupportedFileFormatError` explaining what to do rather than failing somewhere inside libCZI. Older aicspylibczi releases have no remote support at all and keep working for local reads, which is why the dependency pin is unchanged for now — it should be raised once aicspylibczi#135 ships.

## Testing

- New `test_remote.py`: URI classification, presign success/failure paths, and end-to-end remote reads compared byte-for-byte against the same file read off disk (eager and dask paths), plus missing-file and non-CZI error cases. These run against a new session fixture that serves the test resources over HTTP **with range support**, so they are fast and need no network.
- A real `s3://` read of the public `allencell` bucket, anonymously, exercising the whole presign path (adds `s3fs` to the test extra).
- The existing pylibczirw remote test now reads pixels, not just shape, plus monkeypatched tests that local paths are not routed through curl and remote URIs are.
- The localhost tests cover aicspylibczi mode only: pylibCZIrw validates URLs with the `validators` package, which rejects TLD-less hostnames (`http://localhost:8000/a.czi`), and its curl reader stalls on a loopback IP without ever opening a connection. pylibczirw remote coverage stays on the real S3 URL.
- Full suite passes both with an aicspylibczi built from #135 (99 passed) and with released aicspylibczi 3.2.1 (93 passed, 6 skipped) — i.e. the degrade path works.

### Bug found while testing

`fsspec`'s `HTTPFileSystem.unstrip_protocol` prepends `https://` to anything not already starting with `https`, so a plain `http://host/a.czi` became `https://http://host/a.czi`. Fixed, with a regression test.

## Not included

`cache_options` for pylibczirw (last bullet of #112). Both readers open and close the CZI per read call, so a cache scoped to a single `open_czi` can essentially never hit — it would be a knob that does nothing until the reader holds a `CziReader` open across calls. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)